### PR TITLE
Fix license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,469 +1,427 @@
-Atribución/Reconocimiento-CompartirIgual 4.0 Internacional
+Attribution-ShareAlike 4.0 International
 
 =======================================================================
 
-Creative Commons Corporation ("Creative Commons") no es una firma de
-abogados ni ofrece servicios legales ni asesoría legal. La distribución
-de las licencias públicas de Creative Commons no genera una relación
-abogado-cliente ni de cualquier otro tipo. Creative Commons proporciona
-sus licencias y la información relacionada tal como se presenta.
-Creative Commons no ofrece ninguna garantía con respecto a sus
-licencias, ni sobre el material sujeto a sus términos y condiciones, ni
-sobre cualquier información relacionada. Creative Commons queda exenta
-de cualquier responsabilidad vinculada a daños que resulten de su uso
-conforme al marco legal aplicable.
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
 
-Uso de las Licencias Públicas de Creative Commons
+Using Creative Commons Public Licenses
 
-Las licencias públicas de Creative Commons proporcionan un conjunto
-estándar de términos y condiciones que los creadores y otros titulares
-de derechos pueden utilizar para compartir obras originales de su
-autoría y cualquier otro material sujeto a derechos de autor y a otros
-derechos que se especifican en la licencia pública de más abajo. Las
-consideraciones siguientes son solo con fines informativos, no son
-exhaustivas y no forman parte de nuestras licencias.
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
 
-     Consideraciones para licenciantes: Nuestras licencias públicas
-     están destinadas a ser utilizadas por aquellos autorizados a dar
-     permiso al público para utilizar material en formas que de otra
-     manera estarían restringidas por los derechos de autor y por otros
-     derechos. Nuestras licencias son irrevocables. Los licenciantes
-     deben leer y entender los términos y las condiciones de la
-     licencia que elijan antes de aplicarla. Los licenciantes deben
-     también contar con todos los derechos necesarios antes de aplicar
-     nuestras licencias, de modo que el público pueda reutilizar el
-     material según lo esperado. Los licenciantes deben identificar con
-     claridad cualquier material que no esté sujeto a la licencia. Esto
-     incluye materiales que se encuentren distribuidos con otra
-     licencia de CC o materiales utilizados en virtud de alguna
-     excepción o limitación al derecho de autor. Más consideraciones
-     para Licenciantes:
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
      wiki.creativecommons.org/Considerations_for_licensors
 
-     Consideraciones para el público: Mediante el uso de una de
-     nuestras licencias públicas, el licenciante concede el permiso
-     para utilizar el Material Licenciado bajo los términos y las
-     condiciones que se especifican. Si producto de la aplicación de
-     una excepción o limitación al derecho de autor u otra razón, no es
-     necesario aplicar la licencia para el uso requerido, se entenderá
-     que dicho uso no se encuentra regulado por la licencia. Nuestras
-     licencias solamente otorgan los permisos que por derecho de autor
-     y derechos conexos el licenciante tiene potestad legal de otorgar.
-     El uso del Material Licenciado podría estar restringido por
-     razones distintas de la licencia, incluyendo el ejercicio de otros
-     derechos de autor u otros derechos sobre el material. El
-     licenciante puede solicitar peticiones especiales, como pedir que
-     los cambios estén marcados o descritos. Aunque nuestras licencias
-     no lo requieren, se lo alienta a respetar esas solicitudes dentro
-     de lo razonable. Más consideraciones para licenciatarios:
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
      wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
-Creative Commons Atribución/Reconocimiento-CompartirIgual 4.0 Licencia
-Pública Internacional — CC BY-SA 4.0
-
-Al ejercer los Derechos Licenciados (definidos a continuación), Usted
-acepta y acuerda estar obligado por los términos y condiciones de esta
-Licencia Internacional Pública de
-Atribución/Reconocimiento-CompartirIgual 4.0 de Creative Commons
-("Licencia Pública"). En la medida en que esta Licencia Pública pueda
-ser interpretada como un contrato, a Usted se le otorgan los Derechos
-Licenciados en consideración a su aceptación de estos términos y
-condiciones, y el Licenciante le concede a Usted tales derechos en
-consideración a los beneficios que el Licenciante recibe por poner a
-disposición el Material Licenciado bajo estos términos y condiciones.
-
-
-Sección 1 -- Definiciones.
-
-  a. Material Adaptado es aquel material protegido por Derechos de
-     Autor y Derechos Similares que se deriva o se crea en base al
-     Material Licenciado y en el cual el Material Licenciado se
-     traduce, altera, arregla, transforma o modifica de manera tal que
-     dicho resultado sea de aquellos que requieran autorización de
-     acuerdo con los Derechos de Autor y Derechos Similares que ostenta
-     el Licenciante. A los efectos de esta Licencia Pública, cuando el
-     Material Licenciado se trate de una obra musical, una
-     interpretación o una grabación sonora, la sincronización temporal
-     de este material con una imagen en movimiento siempre producirá
-     Material Adaptado.
-
-  b. Licencia de adaptador es aquella licencia que Usted aplica a Sus
-     Derechos de Autor y Derechos Similares en Sus contribuciones
-     consideradas como Material Adaptado de acuerdo con los términos y
-     condiciones de esta Licencia Pública.
-
-  c. Una Licencia Compatible con BY-SA es aquella que aparece en la
-     lista disponible en creativecommons.org/compatiblelicenses,
-     aprobada por Creative Commons, como una licencia esencialmente
-     equivalente a esta Licencia Pública.
-
-  d. Derechos de Autor y Derechos Similares son todos aquellos derechos
-     estrechamente vinculados a los derechos de autor, incluidos, de
-     manera enunciativa y no taxativa, los derechos sobre las
-     interpretaciones, las emisiones, las grabaciones sonoras y los
-     Derechos "Sui Generis" sobre Bases de Datos, sin importar cómo
-     estos derechos se encuentren enunciados o categorizados. A los
-     efectos de esta Licencia Pública, los derechos especificados en
-     las secciones 2(b)(1)-(2) no se consideran Derechos de Autor y
-     Derechos Similares.
-
-  e. Medidas Tecnológicas Efectivas son aquellas medidas que, en
-     ausencia de la debida autorización, no pueden ser eludidas en
-     virtud de las leyes que cumplen las obligaciones del artículo 11
-     del Tratado de la OMPI sobre Derecho de Autor adoptado el 20 de
-     diciembre de 1996, y/o acuerdos internacionales similares.
-
-  f. Excepciones y Limitaciones son el uso justo (fair use), el trato
-     justo (fair dealing) y/o cualquier otra excepción o limitación a
-     los Derechos de Autor y Derechos Similares que se apliquen al uso
-     el Material Licenciado.
-
-  g. Elementos de la Licencia son los atributos que figuran en el
-     nombre de la Licencia Pública de Creative Commons. Los Elementos
-     de la Licencia de esta Licencia Pública son
-     Atribución/Reconocimiento y CompartirIgual.
-
-  h. Material Licenciado es obra artística o literaria, base de datos o
-     cualquier otro material al cual el Licenciante aplicó esta
-     Licencia Pública.
-
-  i. Derechos Licenciados son derechos otorgados a Usted bajo los
-     términos y condiciones de esta Licencia Pública, los cuales se
-     limitan a todos los Derechos de Autor y Derechos Similares que
-     apliquen al uso del Material Licenciado y que el Licenciante tiene
-     potestad legal para licenciar.
-
-  j. Licenciante es el individuo(s) o la entidad(es) que concede
-     derechos bajo esta Licencia Pública.
-
-  k. Compartir significa proporcionar material al público por cualquier
-     medio o procedimiento que requiera permiso conforme a los Derechos
-     Licenciados, tales como la reproducción, exhibición pública,
-     presentación pública, distribución, difusión, comunicación o
-     importación, así como también su puesta a disposición, incluyendo
-     formas en que el público pueda acceder al material desde un lugar
-     y momento elegido individualmente por ellos.
-
-  l. Derechos "Sui Generis" sobre Bases de Datos son aquellos derechos
-     diferentes a los derechos de autor, resultantes de la Directiva
-     96/9/EC del Parlamento Europeo y del Consejo, de 11 de marzo de
-     1996 sobre la protección jurídica de las bases de datos, en sus
-     versiones modificadas y/o posteriores, así como otros derechos
-     esencialmente equivalentes en cualquier otra parte del mundo.
-
-  m. Usted es el individuo o la entidad que ejerce los Derechos
-     Licenciados en esta Licencia Pública. La palabra Su tiene un
-     significado equivalente.
-
-
-Sección 2 -- Ámbito de Aplicación.
-
-  a. Otorgamiento de la licencia.
-
-       1. Sujeto a los términos y condiciones de esta Licencia Pública,
-          el Licenciante le otorga a Usted una licencia de carácter
-          global, gratuita, no transferible a terceros, no exclusiva e
-          irrevocable para ejercer los Derechos Licenciados sobre el
-          Material Licenciado para:
-
-            a. reproducir y Compartir el Material Licenciado, en su
-               totalidad o en parte; y
-
-            b. producir, reproducir y Compartir Material Adaptado.
-
-       2. Excepciones y Limitaciones. Para evitar cualquier duda, donde
-          se apliquen Excepciones y Limitaciones al uso del Material
-          Licenciado, esta Licencia Pública no será aplicable, y Usted
-          no tendrá necesidad de cumplir con sus términos y
-          condiciones.
-
-       3. Vigencia. La vigencia de esta Licencia Pública está
-          especificada en la sección 6(a).
-
-       4. Medios y formatos; modificaciones técnicas permitidas. El
-          Licenciante le autoriza a Usted a ejercer los Derechos
-          Licenciados en todos los medios y formatos, actualmente
-          conocidos o por crearse en el futuro, y a realizar las
-          modificaciones técnicas necesarias para ello. El Licenciante
-          renuncia y/o se compromete a no hacer valer cualquier derecho
-          o potestad para prohibirle a Usted realizar las
-          modificaciones técnicas necesarias para ejercer los Derechos
-          Licenciados, incluyendo las modificaciones técnicas
-          necesarias para eludir las Medidas Tecnológicas Efectivas. A
-          los efectos de esta Licencia Pública, la mera realización de
-          modificaciones autorizadas por esta sección 2(a)(4) nunca
-          produce Material Adaptado.
-
-       5. Receptores posteriores.
-
-            a. Oferta del Licenciante – Material Licenciado. Cada
-               receptor de Material Licenciado recibe automáticamente
-               una oferta del Licenciante para ejercer los Derechos
-               Licenciados bajo los términos y condiciones de esta
-               Licencia Pública.
-
-            b. Oferta adicional por parte del Licenciante – Material
-               Adaptado. Cada receptor del Material Adaptado por Usted
-               recibe automáticamente una oferta del Licenciante para
-               ejercer los Derechos Licenciados en el Material Adaptado
-               bajo las condiciones de la Licencia del Adaptador que
-               Usted aplique.
-
-            c. Sin restricciones a receptores posteriores. Usted no
-               puede ofrecer o imponer ningún término ni condición
-               diferente o adicional, ni puede aplicar ninguna Medida
-               Tecnológica Efectiva al Material Licenciado si
-               haciéndolo restringe el ejercicio d
-
-       6. Sin endoso. Nada de lo contenido en esta Licencia Pública
-          constituye o puede interpretarse como un permiso para afirmar
-          o implicar que Usted, o que Su uso del Material Licenciado,
-          está conectado, patrocinado, respaldado o reconocido con
-          estatus oficial por el Licenciante u otros designados para
-          recibir la Atribución/Reconocimiento según lo dispuesto en la
-          sección 3(a)(1)(A)(i).
-
-  b. Otros derechos.
-
-       1. Los derechos morales, tales como el derecho a la integridad,
-          no están comprendidos bajo esta Licencia Pública ni tampoco
-          los derechos de publicidad y privacidad ni otros derechos
-          personales similares. Sin embargo, en la medida de lo
-          posible, el Licenciante renuncia y/o se compromete a no hacer
-          valer ninguno de estos derechos que ostenta como Licenciante,
-          limitándose a lo necesario para que Usted pueda ejercer los
-          Derechos Licenciados, pero no de otra manera.
-
-       2. Los derechos de patentes y marcas no son objeto de esta
-          Licencia Pública.
-
-       3. En la medida de lo posible, el Licenciante renuncia al
-          derecho de cobrarle regalías a Usted por el ejercicio de los
-          Derechos Licenciados, ya sea directamente o a través de una
-          entidad de gestión colectiva bajo cualquier esquema de
-          licenciamiento voluntario, renunciable o no renunciable. En
-          todos los demás casos, el Licenciante se reserva expresamente
-          cualquier derecho de cobrar esas regalías.
-
-
-Sección 3 -- Condiciones de la Licencia.
-
-Su ejercicio de los Derechos Licenciados está expresamente sujeto a las
-condiciones siguientes.
-
-  a. Atribución/Reconocimiento.
-
-       1. Si Usted comparte el Material Licenciado (incluyendo en forma
-          modificada), Usted debe:
-
-            a. Conservar lo siguiente si es facilitado por el
-               Licenciante con el Material Licenciado:
-
-                 i. identificación del creador o los creadores del
-                    Material Licenciado y de cualquier otra persona
-                    designada para recibir Atribución/Reconocimiento,
-                    de cualquier manera razonable solicitada por el
-                    Licenciante (incluyendo por seudónimo si este ha
-                    sido designado);
-
-                ii. un aviso sobre derecho de autor;
-
-               iii. un aviso que se refiera a esta Licencia Pública;
-
-                iv. un aviso que se refiera a la limitación de
-                    garantías;
-
-                 v. un URI o un hipervínculo al Material Licenciado en
-                    la medida razonablemente posible;
-
-            b. Indicar si Usted modificó el Material Licenciado y
-               conservar una indicación de las modificaciones
-               anteriores; e
-
-            c. Indicar que el Material Licenciado está bajo esta
-               Licencia Pública, e incluir el texto, el URI o el
-               hipervínculo a esta Licencia Pública.
-
-       2. Usted puede satisfacer las condiciones de la sección 3(a)(1)
-          de cualquier forma razonable según el medio, las maneras y el
-          contexto en los cuales Usted Comparta el Material Licenciado.
-          Por ejemplo, puede ser razonable satisfacer las condiciones
-          facilitando un URI o un hipervínculo a un recurso que incluya
-          la información requerida.
-
-       3. Bajo requerimiento del Licenciante, Usted debe eliminar
-          cualquier información requerida por la sección 3(a)(1)(A) en
-          la medida razonablemente posible.
-
-  b. CompartirIgual.
-
-     Además de las condiciones de la sección 3(a), si Usted Comparte
-     Material Adaptado producido por Usted, también aplican las
-     condiciones siguientes.
-
-       1. La Licencia del Adaptador que Usted aplique debe ser una
-          licencia de Creative Commons con los mismos Elementos de la
-          Licencia, ya sea de esta versión o una posterior, o una
-          Licencia Compatible con la BY-SA.
-
-       2. Usted debe incluir el texto, el URI o el hipervínculo a la
-          Licencia del Adaptador que aplique. Usted puede satisfacer
-          esta condición de cualquier forma razonable según el medio,
-          las maneras y el contexto en los cuales Usted Comparta el
-          Material Adaptado.
-
-       3. Usted no puede ofrecer o imponer ningún término o condición
-          adicional o diferente, o aplicar ninguna Medida Tecnológica
-          Efectiva al Material Adaptado que restrinja el ejercicio de
-          los derechos concedidos en virtud de la Licencia de Adaptador
-          que Usted aplique.
-
-
-Sección 4 -- Derechos "Sui Generis" sobre Bases de Datos.
-
-Cuando los Derechos Licenciados incluyan Derechos "Sui Generis" sobre
-Bases de Datos que apliquen a Su uso del Material Licenciado:
-
-  a. para evitar cualquier duda, la sección 2(a)(1) le concede a Usted
-     el derecho a extraer, reutilizar, reproducir y Compartir todo o
-     una parte sustancial de los contenidos de la base de datos;
-
-  b. si Usted incluye la totalidad o una parte sustancial del contenido
-     de una base de datos en otra sobre la cual Usted ostenta Derecho
-     "Sui Generis" sobre Bases de Datos, entonces ella (pero no sus
-     contenidos individuales) se entenderá como Material Adaptado
-
-     para efectos de la sección 3(b); y
-  c. Usted debe cumplir con las condiciones de la sección 3(a) si Usted
-     Comparte la totalidad o una parte sustancial de los contenidos de
-     la base de datos.
-
-Para evitar dudas, esta sección 4 complementa y no sustituye Sus
-obligaciones bajo esta Licencia Pública cuando los Derechos Licenciados
-incluyen otros Derechos de Autor y Derechos Similares.
-
-
-Sección 5 -- Exención de Garantías y Limitación de Responsabilidad.
-
-  a. SALVO QUE EL LICENCIANTE SE HAYA COMPROMETIDO MEDIANTE UN ACUERDO
-     POR SEPARADO, EN LA MEDIDA DE LO POSIBLE EL LICENCIANTE OFRECE EL
-     MATERIAL LICENCIADO TAL COMO ES Y TAL COMO ESTÁ DISPONIBLE Y NO SE
-     HACE RESPONSABLE NI OFRECE GARANTÍAS DE NINGÚN TIPO RESPECTO AL
-     MATERIAL LICENCIADO, YA SEA DE MANERA EXPRESA, IMPLÍCITA, LEGAL U
-     OTRA. ESTO INCLUYE, DE MANERA NO TAXATIVA, LAS GARANTÍAS DE
-     TÍTULO, COMERCIABILIDAD, IDONEIDAD PARA UN PROPÓSITO EN
-     PARTICULAR, NO INFRACCIÓN, AUSENCIA DE VICIOS OCULTOS U OTROS
-     DEFECTOS, LA EXACTITUD, LA PRESENCIA O LA AUSENCIA DE ERRORES,
-     SEAN O NO CONOCIDOS O DETECTABLES. CUANDO NO SE PERMITA,
-     TOTALMENTE O EN PARTE, LA DECLARACIÓN DE AUSENCIA DE GARANTÍAS, A
-     USTED PUEDE NO APLICÁRSELE ESTA EXCLUSIÓN.
-
-  b. EN LA MEDIDA DE LO POSIBLE, EN NINGÚN CASO EL LICENCIANTE SERÁ
-     RESPONSABLE ANTE USTED POR NINGUNA TEORÍA LEGAL (INCLUYENDO, DE
-     MANERA NO TAXATIVA, LA NEGLIGENCIA) O DE OTRA MANERA POR CUALQUIER
-     PÉRDIDA, COSTE, GASTO O DAÑO DIRECTO, ESPECIAL, INDIRECTO,
-     INCIDENTAL, CONSECUENTE, PUNITIVO, EJEMPLAR U OTRO QUE SURJA DE
-     ESTA LICENCIA PÚBLICA O DEL USO DEL MATERIAL LICENCIADO, INCLUSO
-     CUANDO EL LICENCIANTE HAYA SIDO ADVERTIDO DE LA POSIBILIDAD DE
-     TALES PÉRDIDAS, COSTES, GASTOS O DAÑOS. CUANDO NO SE PERMITA LA
-     LIMITACIÓN DE RESPONSABILIDAD, YA SEA TOTALMENTE O EN PARTE, A
-     USTED PUEDE NO APLICÁRSELE ESTA LIMITACIÓN.
-
-  c. La renuncia de garantías y la limitación de responsabilidad
-     descritas anteriormente deberán ser interpretadas, en la medida de
-     lo posible, como lo más próximo a una exención y renuncia absoluta
-     a todo tipo de responsabilidad.
-
-
-Sección 6 -- Vigencia y Terminación.
-
-  a. Esta Licencia Pública tiene una vigencia de aplicación igual al
-     plazo de protección de los Derechos de Autor y Derechos Similares
-     licenciados aquí. Sin embargo, si Usted incumple las condiciones
-     de esta Licencia Pública, los derechos que se le conceden mediante
-     esta Licencia Pública terminan automáticamente.
-
-  b. En aquellos casos en que Su derecho a utilizar el Material
-     Licenciado se haya terminado conforme a la sección 6(a), este será
-     restablecido:
-
-       1. automáticamente a partir de la fecha en que la violación sea
-          subsanada, siempre y cuando esta se subsane dentro de los 30
-          días siguientes a partir de Su descubrimiento de la
-          violación; o
-
-       2. tras el restablecimiento expreso por parte del Licenciante.
-
-     Para evitar dudas, esta sección 6(b) no afecta ningún derecho que
-     pueda tener el Licenciante a buscar resarcimiento por Sus
-     violaciones de esta Licencia Pública.
-
-  c. Para evitar dudas, el Licenciante también puede ofrecer el
-     Material Licenciado bajo términos o condiciones diferentes, o
-     dejar de distribuir el Material Licenciado en cualquier momento;
-     sin embargo, hacer esto no pondrá fin a esta Licencia Pública.
-
-  d. Las secciones 1, 5, 6, 7, y 8 permanecerán vigentes a la
-     terminación de esta Licencia Pública.
-
-
-Sección 7 -- Otros Términos y Condiciones.
-
-  a. El Licenciante no estará obligado por ningún término o condición
-     adicional o diferente que Usted le comunique a menos que se
-     acuerde expresamente.
-
-  b. Cualquier arreglo, convenio o acuerdo en relación con el Material
-     Licenciado que no se indique en este documento se considera
-     separado e independiente de los términos y condiciones de esta
-     Licencia Pública.
-
-
-Sección 8 -- Interpretación.
-
-  a. Para evitar dudas, esta Licencia Pública no es ni deberá
-     interpretarse como una reducción, limitación, restricción, o una
-     imposición de condiciones al uso de Material Licenciado que
-     legalmente pueda realizarse sin permiso del titular, más allá de
-     lo contemplado en esta Licencia Pública.
-
-  b. En la medida de lo posible, si alguna disposición de esta Licencia
-     Pública se considera inaplicable, esta será automáticamente
-     modificada en la medida mínima necesaria para hacerla aplicable.
-     Si la disposición no puede ser reformada, deberá ser eliminada de
-     esta Licencia Pública sin afectar la exigibilidad de los términos
-     y condiciones restantes.
-
-  c. No se podrá renunciar a ningún término o condición de esta
-     Licencia Pública, ni se consentirá ningún incumplimiento, a menos
-     que se acuerde expresamente con el Licenciante.
-
-  d. Nada en esta Licencia Pública constituye ni puede ser interpretado
-     como una limitación o una renuncia a los privilegios e inmunidades
-     que aplican al Licenciante o a Usted, incluyendo aquellos surgidos
-     a partir de procesos legales de cualquier jurisdicción o
-     autoridad.
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
 
 
 =======================================================================
 
-Creative Commons no es una parte en sus licencias públicas. No
-obstante, Creative Commons puede optar por aplicar una de sus licencias
-públicas al material que publica y en estos casos debe ser considerado
-como el “Licenciante”. El texto de las licencias públicas de Creative
-Commons está dedicado al dominio público bajo una licencia CC0 de
-Dedicación al Dominio Público. Excepto con el propósito limitado de
-indicar que el material se comparte bajo una licencia pública de
-Creative Commons o según lo permitido por las políticas de Creative
-Commons publicadas en creativecommons.org/policies, Creative Commons no
-autoriza el uso de la marca “Creative Commons” o cualquier otra marca o
-logotipo de Creative Commons sin su consentimiento previo por escrito,
-incluso, de manera enunciativa y no taxativa, en relación con
-modificaciones no autorizadas de cualquiera de sus licencias públicas o
-de cualquier otro acuerdo, arreglo o convenio relativos al uso de
-Material Licenciado. Para evitar cualquier duda, este párrafo no forma
-parte de las licencias públicas.
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
 
-Puede contactarse con Creative Commons en creativecommons.org.
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Meshtastic Spanish Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-CODE_es
+++ b/LICENSE-CODE_es
@@ -1,0 +1,22 @@
+Licencia MIT
+
+Copyright (c) 2025 Meshtastic Spanish Community
+
+Por la presente se concede permiso, libre de cargos, a cualquier persona que
+obtenga una copia de este software y de los archivos de documentación asociados
+(el "Software"), a utilizar el Software sin restricción, incluyendo sin
+limitación los derechos a usar, copiar, modificar, fusionar, publicar,
+distribuir, sublicenciar, y/o vender copias del Software, y a permitir a las
+personas a las que se les proporcione el Software a hacer lo mismo, sujeto a
+las siguientes condiciones:
+
+El aviso de copyright anterior y este aviso de permiso se incluirán en todas
+las copias o partes sustanciales del Software.
+
+EL SOFTWARE SE PROPORCIONA "COMO ESTÁ", SIN GARANTÍA DE NINGÚN TIPO, EXPRESA O
+IMPLÍCITA, INCLUYENDO PERO NO LIMITADO A GARANTÍAS DE COMERCIALIZACIÓN,
+IDONEIDAD PARA UN PROPÓSITO PARTICULAR E INCUMPLIMIENTO. EN NINGÚN CASO LOS
+AUTORES O PROPIETARIOS DE LOS DERECHOS DE AUTOR SERÁN RESPONSABLES DE NINGUNA
+RECLAMACIÓN, DAÑOS U OTRAS RESPONSABILIDADES, YA SEA EN UNA ACCIÓN DE CONTRATO,
+AGRAVIO O CUALQUIER OTRO MOTIVO, DERIVADAS DE, FUERA DE O EN CONEXIÓN CON EL
+SOFTWARE O SU USO U OTRO TIPO DE ACCIONES EN EL SOFTWARE.

--- a/LICENSE_es
+++ b/LICENSE_es
@@ -1,0 +1,469 @@
+Atribución/Reconocimiento-CompartirIgual 4.0 Internacional
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") no es una firma de
+abogados ni ofrece servicios legales ni asesoría legal. La distribución
+de las licencias públicas de Creative Commons no genera una relación
+abogado-cliente ni de cualquier otro tipo. Creative Commons proporciona
+sus licencias y la información relacionada tal como se presenta.
+Creative Commons no ofrece ninguna garantía con respecto a sus
+licencias, ni sobre el material sujeto a sus términos y condiciones, ni
+sobre cualquier información relacionada. Creative Commons queda exenta
+de cualquier responsabilidad vinculada a daños que resulten de su uso
+conforme al marco legal aplicable.
+
+Uso de las Licencias Públicas de Creative Commons
+
+Las licencias públicas de Creative Commons proporcionan un conjunto
+estándar de términos y condiciones que los creadores y otros titulares
+de derechos pueden utilizar para compartir obras originales de su
+autoría y cualquier otro material sujeto a derechos de autor y a otros
+derechos que se especifican en la licencia pública de más abajo. Las
+consideraciones siguientes son solo con fines informativos, no son
+exhaustivas y no forman parte de nuestras licencias.
+
+     Consideraciones para licenciantes: Nuestras licencias públicas
+     están destinadas a ser utilizadas por aquellos autorizados a dar
+     permiso al público para utilizar material en formas que de otra
+     manera estarían restringidas por los derechos de autor y por otros
+     derechos. Nuestras licencias son irrevocables. Los licenciantes
+     deben leer y entender los términos y las condiciones de la
+     licencia que elijan antes de aplicarla. Los licenciantes deben
+     también contar con todos los derechos necesarios antes de aplicar
+     nuestras licencias, de modo que el público pueda reutilizar el
+     material según lo esperado. Los licenciantes deben identificar con
+     claridad cualquier material que no esté sujeto a la licencia. Esto
+     incluye materiales que se encuentren distribuidos con otra
+     licencia de CC o materiales utilizados en virtud de alguna
+     excepción o limitación al derecho de autor. Más consideraciones
+     para Licenciantes:
+     wiki.creativecommons.org/Considerations_for_licensors
+
+     Consideraciones para el público: Mediante el uso de una de
+     nuestras licencias públicas, el licenciante concede el permiso
+     para utilizar el Material Licenciado bajo los términos y las
+     condiciones que se especifican. Si producto de la aplicación de
+     una excepción o limitación al derecho de autor u otra razón, no es
+     necesario aplicar la licencia para el uso requerido, se entenderá
+     que dicho uso no se encuentra regulado por la licencia. Nuestras
+     licencias solamente otorgan los permisos que por derecho de autor
+     y derechos conexos el licenciante tiene potestad legal de otorgar.
+     El uso del Material Licenciado podría estar restringido por
+     razones distintas de la licencia, incluyendo el ejercicio de otros
+     derechos de autor u otros derechos sobre el material. El
+     licenciante puede solicitar peticiones especiales, como pedir que
+     los cambios estén marcados o descritos. Aunque nuestras licencias
+     no lo requieren, se lo alienta a respetar esas solicitudes dentro
+     de lo razonable. Más consideraciones para licenciatarios:
+     wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Atribución/Reconocimiento-CompartirIgual 4.0 Licencia
+Pública Internacional — CC BY-SA 4.0
+
+Al ejercer los Derechos Licenciados (definidos a continuación), Usted
+acepta y acuerda estar obligado por los términos y condiciones de esta
+Licencia Internacional Pública de
+Atribución/Reconocimiento-CompartirIgual 4.0 de Creative Commons
+("Licencia Pública"). En la medida en que esta Licencia Pública pueda
+ser interpretada como un contrato, a Usted se le otorgan los Derechos
+Licenciados en consideración a su aceptación de estos términos y
+condiciones, y el Licenciante le concede a Usted tales derechos en
+consideración a los beneficios que el Licenciante recibe por poner a
+disposición el Material Licenciado bajo estos términos y condiciones.
+
+
+Sección 1 -- Definiciones.
+
+  a. Material Adaptado es aquel material protegido por Derechos de
+     Autor y Derechos Similares que se deriva o se crea en base al
+     Material Licenciado y en el cual el Material Licenciado se
+     traduce, altera, arregla, transforma o modifica de manera tal que
+     dicho resultado sea de aquellos que requieran autorización de
+     acuerdo con los Derechos de Autor y Derechos Similares que ostenta
+     el Licenciante. A los efectos de esta Licencia Pública, cuando el
+     Material Licenciado se trate de una obra musical, una
+     interpretación o una grabación sonora, la sincronización temporal
+     de este material con una imagen en movimiento siempre producirá
+     Material Adaptado.
+
+  b. Licencia de adaptador es aquella licencia que Usted aplica a Sus
+     Derechos de Autor y Derechos Similares en Sus contribuciones
+     consideradas como Material Adaptado de acuerdo con los términos y
+     condiciones de esta Licencia Pública.
+
+  c. Una Licencia Compatible con BY-SA es aquella que aparece en la
+     lista disponible en creativecommons.org/compatiblelicenses,
+     aprobada por Creative Commons, como una licencia esencialmente
+     equivalente a esta Licencia Pública.
+
+  d. Derechos de Autor y Derechos Similares son todos aquellos derechos
+     estrechamente vinculados a los derechos de autor, incluidos, de
+     manera enunciativa y no taxativa, los derechos sobre las
+     interpretaciones, las emisiones, las grabaciones sonoras y los
+     Derechos "Sui Generis" sobre Bases de Datos, sin importar cómo
+     estos derechos se encuentren enunciados o categorizados. A los
+     efectos de esta Licencia Pública, los derechos especificados en
+     las secciones 2(b)(1)-(2) no se consideran Derechos de Autor y
+     Derechos Similares.
+
+  e. Medidas Tecnológicas Efectivas son aquellas medidas que, en
+     ausencia de la debida autorización, no pueden ser eludidas en
+     virtud de las leyes que cumplen las obligaciones del artículo 11
+     del Tratado de la OMPI sobre Derecho de Autor adoptado el 20 de
+     diciembre de 1996, y/o acuerdos internacionales similares.
+
+  f. Excepciones y Limitaciones son el uso justo (fair use), el trato
+     justo (fair dealing) y/o cualquier otra excepción o limitación a
+     los Derechos de Autor y Derechos Similares que se apliquen al uso
+     el Material Licenciado.
+
+  g. Elementos de la Licencia son los atributos que figuran en el
+     nombre de la Licencia Pública de Creative Commons. Los Elementos
+     de la Licencia de esta Licencia Pública son
+     Atribución/Reconocimiento y CompartirIgual.
+
+  h. Material Licenciado es obra artística o literaria, base de datos o
+     cualquier otro material al cual el Licenciante aplicó esta
+     Licencia Pública.
+
+  i. Derechos Licenciados son derechos otorgados a Usted bajo los
+     términos y condiciones de esta Licencia Pública, los cuales se
+     limitan a todos los Derechos de Autor y Derechos Similares que
+     apliquen al uso del Material Licenciado y que el Licenciante tiene
+     potestad legal para licenciar.
+
+  j. Licenciante es el individuo(s) o la entidad(es) que concede
+     derechos bajo esta Licencia Pública.
+
+  k. Compartir significa proporcionar material al público por cualquier
+     medio o procedimiento que requiera permiso conforme a los Derechos
+     Licenciados, tales como la reproducción, exhibición pública,
+     presentación pública, distribución, difusión, comunicación o
+     importación, así como también su puesta a disposición, incluyendo
+     formas en que el público pueda acceder al material desde un lugar
+     y momento elegido individualmente por ellos.
+
+  l. Derechos "Sui Generis" sobre Bases de Datos son aquellos derechos
+     diferentes a los derechos de autor, resultantes de la Directiva
+     96/9/EC del Parlamento Europeo y del Consejo, de 11 de marzo de
+     1996 sobre la protección jurídica de las bases de datos, en sus
+     versiones modificadas y/o posteriores, así como otros derechos
+     esencialmente equivalentes en cualquier otra parte del mundo.
+
+  m. Usted es el individuo o la entidad que ejerce los Derechos
+     Licenciados en esta Licencia Pública. La palabra Su tiene un
+     significado equivalente.
+
+
+Sección 2 -- Ámbito de Aplicación.
+
+  a. Otorgamiento de la licencia.
+
+       1. Sujeto a los términos y condiciones de esta Licencia Pública,
+          el Licenciante le otorga a Usted una licencia de carácter
+          global, gratuita, no transferible a terceros, no exclusiva e
+          irrevocable para ejercer los Derechos Licenciados sobre el
+          Material Licenciado para:
+
+            a. reproducir y Compartir el Material Licenciado, en su
+               totalidad o en parte; y
+
+            b. producir, reproducir y Compartir Material Adaptado.
+
+       2. Excepciones y Limitaciones. Para evitar cualquier duda, donde
+          se apliquen Excepciones y Limitaciones al uso del Material
+          Licenciado, esta Licencia Pública no será aplicable, y Usted
+          no tendrá necesidad de cumplir con sus términos y
+          condiciones.
+
+       3. Vigencia. La vigencia de esta Licencia Pública está
+          especificada en la sección 6(a).
+
+       4. Medios y formatos; modificaciones técnicas permitidas. El
+          Licenciante le autoriza a Usted a ejercer los Derechos
+          Licenciados en todos los medios y formatos, actualmente
+          conocidos o por crearse en el futuro, y a realizar las
+          modificaciones técnicas necesarias para ello. El Licenciante
+          renuncia y/o se compromete a no hacer valer cualquier derecho
+          o potestad para prohibirle a Usted realizar las
+          modificaciones técnicas necesarias para ejercer los Derechos
+          Licenciados, incluyendo las modificaciones técnicas
+          necesarias para eludir las Medidas Tecnológicas Efectivas. A
+          los efectos de esta Licencia Pública, la mera realización de
+          modificaciones autorizadas por esta sección 2(a)(4) nunca
+          produce Material Adaptado.
+
+       5. Receptores posteriores.
+
+            a. Oferta del Licenciante – Material Licenciado. Cada
+               receptor de Material Licenciado recibe automáticamente
+               una oferta del Licenciante para ejercer los Derechos
+               Licenciados bajo los términos y condiciones de esta
+               Licencia Pública.
+
+            b. Oferta adicional por parte del Licenciante – Material
+               Adaptado. Cada receptor del Material Adaptado por Usted
+               recibe automáticamente una oferta del Licenciante para
+               ejercer los Derechos Licenciados en el Material Adaptado
+               bajo las condiciones de la Licencia del Adaptador que
+               Usted aplique.
+
+            c. Sin restricciones a receptores posteriores. Usted no
+               puede ofrecer o imponer ningún término ni condición
+               diferente o adicional, ni puede aplicar ninguna Medida
+               Tecnológica Efectiva al Material Licenciado si
+               haciéndolo restringe el ejercicio d
+
+       6. Sin endoso. Nada de lo contenido en esta Licencia Pública
+          constituye o puede interpretarse como un permiso para afirmar
+          o implicar que Usted, o que Su uso del Material Licenciado,
+          está conectado, patrocinado, respaldado o reconocido con
+          estatus oficial por el Licenciante u otros designados para
+          recibir la Atribución/Reconocimiento según lo dispuesto en la
+          sección 3(a)(1)(A)(i).
+
+  b. Otros derechos.
+
+       1. Los derechos morales, tales como el derecho a la integridad,
+          no están comprendidos bajo esta Licencia Pública ni tampoco
+          los derechos de publicidad y privacidad ni otros derechos
+          personales similares. Sin embargo, en la medida de lo
+          posible, el Licenciante renuncia y/o se compromete a no hacer
+          valer ninguno de estos derechos que ostenta como Licenciante,
+          limitándose a lo necesario para que Usted pueda ejercer los
+          Derechos Licenciados, pero no de otra manera.
+
+       2. Los derechos de patentes y marcas no son objeto de esta
+          Licencia Pública.
+
+       3. En la medida de lo posible, el Licenciante renuncia al
+          derecho de cobrarle regalías a Usted por el ejercicio de los
+          Derechos Licenciados, ya sea directamente o a través de una
+          entidad de gestión colectiva bajo cualquier esquema de
+          licenciamiento voluntario, renunciable o no renunciable. En
+          todos los demás casos, el Licenciante se reserva expresamente
+          cualquier derecho de cobrar esas regalías.
+
+
+Sección 3 -- Condiciones de la Licencia.
+
+Su ejercicio de los Derechos Licenciados está expresamente sujeto a las
+condiciones siguientes.
+
+  a. Atribución/Reconocimiento.
+
+       1. Si Usted comparte el Material Licenciado (incluyendo en forma
+          modificada), Usted debe:
+
+            a. Conservar lo siguiente si es facilitado por el
+               Licenciante con el Material Licenciado:
+
+                 i. identificación del creador o los creadores del
+                    Material Licenciado y de cualquier otra persona
+                    designada para recibir Atribución/Reconocimiento,
+                    de cualquier manera razonable solicitada por el
+                    Licenciante (incluyendo por seudónimo si este ha
+                    sido designado);
+
+                ii. un aviso sobre derecho de autor;
+
+               iii. un aviso que se refiera a esta Licencia Pública;
+
+                iv. un aviso que se refiera a la limitación de
+                    garantías;
+
+                 v. un URI o un hipervínculo al Material Licenciado en
+                    la medida razonablemente posible;
+
+            b. Indicar si Usted modificó el Material Licenciado y
+               conservar una indicación de las modificaciones
+               anteriores; e
+
+            c. Indicar que el Material Licenciado está bajo esta
+               Licencia Pública, e incluir el texto, el URI o el
+               hipervínculo a esta Licencia Pública.
+
+       2. Usted puede satisfacer las condiciones de la sección 3(a)(1)
+          de cualquier forma razonable según el medio, las maneras y el
+          contexto en los cuales Usted Comparta el Material Licenciado.
+          Por ejemplo, puede ser razonable satisfacer las condiciones
+          facilitando un URI o un hipervínculo a un recurso que incluya
+          la información requerida.
+
+       3. Bajo requerimiento del Licenciante, Usted debe eliminar
+          cualquier información requerida por la sección 3(a)(1)(A) en
+          la medida razonablemente posible.
+
+  b. CompartirIgual.
+
+     Además de las condiciones de la sección 3(a), si Usted Comparte
+     Material Adaptado producido por Usted, también aplican las
+     condiciones siguientes.
+
+       1. La Licencia del Adaptador que Usted aplique debe ser una
+          licencia de Creative Commons con los mismos Elementos de la
+          Licencia, ya sea de esta versión o una posterior, o una
+          Licencia Compatible con la BY-SA.
+
+       2. Usted debe incluir el texto, el URI o el hipervínculo a la
+          Licencia del Adaptador que aplique. Usted puede satisfacer
+          esta condición de cualquier forma razonable según el medio,
+          las maneras y el contexto en los cuales Usted Comparta el
+          Material Adaptado.
+
+       3. Usted no puede ofrecer o imponer ningún término o condición
+          adicional o diferente, o aplicar ninguna Medida Tecnológica
+          Efectiva al Material Adaptado que restrinja el ejercicio de
+          los derechos concedidos en virtud de la Licencia de Adaptador
+          que Usted aplique.
+
+
+Sección 4 -- Derechos "Sui Generis" sobre Bases de Datos.
+
+Cuando los Derechos Licenciados incluyan Derechos "Sui Generis" sobre
+Bases de Datos que apliquen a Su uso del Material Licenciado:
+
+  a. para evitar cualquier duda, la sección 2(a)(1) le concede a Usted
+     el derecho a extraer, reutilizar, reproducir y Compartir todo o
+     una parte sustancial de los contenidos de la base de datos;
+
+  b. si Usted incluye la totalidad o una parte sustancial del contenido
+     de una base de datos en otra sobre la cual Usted ostenta Derecho
+     "Sui Generis" sobre Bases de Datos, entonces ella (pero no sus
+     contenidos individuales) se entenderá como Material Adaptado
+
+     para efectos de la sección 3(b); y
+  c. Usted debe cumplir con las condiciones de la sección 3(a) si Usted
+     Comparte la totalidad o una parte sustancial de los contenidos de
+     la base de datos.
+
+Para evitar dudas, esta sección 4 complementa y no sustituye Sus
+obligaciones bajo esta Licencia Pública cuando los Derechos Licenciados
+incluyen otros Derechos de Autor y Derechos Similares.
+
+
+Sección 5 -- Exención de Garantías y Limitación de Responsabilidad.
+
+  a. SALVO QUE EL LICENCIANTE SE HAYA COMPROMETIDO MEDIANTE UN ACUERDO
+     POR SEPARADO, EN LA MEDIDA DE LO POSIBLE EL LICENCIANTE OFRECE EL
+     MATERIAL LICENCIADO TAL COMO ES Y TAL COMO ESTÁ DISPONIBLE Y NO SE
+     HACE RESPONSABLE NI OFRECE GARANTÍAS DE NINGÚN TIPO RESPECTO AL
+     MATERIAL LICENCIADO, YA SEA DE MANERA EXPRESA, IMPLÍCITA, LEGAL U
+     OTRA. ESTO INCLUYE, DE MANERA NO TAXATIVA, LAS GARANTÍAS DE
+     TÍTULO, COMERCIABILIDAD, IDONEIDAD PARA UN PROPÓSITO EN
+     PARTICULAR, NO INFRACCIÓN, AUSENCIA DE VICIOS OCULTOS U OTROS
+     DEFECTOS, LA EXACTITUD, LA PRESENCIA O LA AUSENCIA DE ERRORES,
+     SEAN O NO CONOCIDOS O DETECTABLES. CUANDO NO SE PERMITA,
+     TOTALMENTE O EN PARTE, LA DECLARACIÓN DE AUSENCIA DE GARANTÍAS, A
+     USTED PUEDE NO APLICÁRSELE ESTA EXCLUSIÓN.
+
+  b. EN LA MEDIDA DE LO POSIBLE, EN NINGÚN CASO EL LICENCIANTE SERÁ
+     RESPONSABLE ANTE USTED POR NINGUNA TEORÍA LEGAL (INCLUYENDO, DE
+     MANERA NO TAXATIVA, LA NEGLIGENCIA) O DE OTRA MANERA POR CUALQUIER
+     PÉRDIDA, COSTE, GASTO O DAÑO DIRECTO, ESPECIAL, INDIRECTO,
+     INCIDENTAL, CONSECUENTE, PUNITIVO, EJEMPLAR U OTRO QUE SURJA DE
+     ESTA LICENCIA PÚBLICA O DEL USO DEL MATERIAL LICENCIADO, INCLUSO
+     CUANDO EL LICENCIANTE HAYA SIDO ADVERTIDO DE LA POSIBILIDAD DE
+     TALES PÉRDIDAS, COSTES, GASTOS O DAÑOS. CUANDO NO SE PERMITA LA
+     LIMITACIÓN DE RESPONSABILIDAD, YA SEA TOTALMENTE O EN PARTE, A
+     USTED PUEDE NO APLICÁRSELE ESTA LIMITACIÓN.
+
+  c. La renuncia de garantías y la limitación de responsabilidad
+     descritas anteriormente deberán ser interpretadas, en la medida de
+     lo posible, como lo más próximo a una exención y renuncia absoluta
+     a todo tipo de responsabilidad.
+
+
+Sección 6 -- Vigencia y Terminación.
+
+  a. Esta Licencia Pública tiene una vigencia de aplicación igual al
+     plazo de protección de los Derechos de Autor y Derechos Similares
+     licenciados aquí. Sin embargo, si Usted incumple las condiciones
+     de esta Licencia Pública, los derechos que se le conceden mediante
+     esta Licencia Pública terminan automáticamente.
+
+  b. En aquellos casos en que Su derecho a utilizar el Material
+     Licenciado se haya terminado conforme a la sección 6(a), este será
+     restablecido:
+
+       1. automáticamente a partir de la fecha en que la violación sea
+          subsanada, siempre y cuando esta se subsane dentro de los 30
+          días siguientes a partir de Su descubrimiento de la
+          violación; o
+
+       2. tras el restablecimiento expreso por parte del Licenciante.
+
+     Para evitar dudas, esta sección 6(b) no afecta ningún derecho que
+     pueda tener el Licenciante a buscar resarcimiento por Sus
+     violaciones de esta Licencia Pública.
+
+  c. Para evitar dudas, el Licenciante también puede ofrecer el
+     Material Licenciado bajo términos o condiciones diferentes, o
+     dejar de distribuir el Material Licenciado en cualquier momento;
+     sin embargo, hacer esto no pondrá fin a esta Licencia Pública.
+
+  d. Las secciones 1, 5, 6, 7, y 8 permanecerán vigentes a la
+     terminación de esta Licencia Pública.
+
+
+Sección 7 -- Otros Términos y Condiciones.
+
+  a. El Licenciante no estará obligado por ningún término o condición
+     adicional o diferente que Usted le comunique a menos que se
+     acuerde expresamente.
+
+  b. Cualquier arreglo, convenio o acuerdo en relación con el Material
+     Licenciado que no se indique en este documento se considera
+     separado e independiente de los términos y condiciones de esta
+     Licencia Pública.
+
+
+Sección 8 -- Interpretación.
+
+  a. Para evitar dudas, esta Licencia Pública no es ni deberá
+     interpretarse como una reducción, limitación, restricción, o una
+     imposición de condiciones al uso de Material Licenciado que
+     legalmente pueda realizarse sin permiso del titular, más allá de
+     lo contemplado en esta Licencia Pública.
+
+  b. En la medida de lo posible, si alguna disposición de esta Licencia
+     Pública se considera inaplicable, esta será automáticamente
+     modificada en la medida mínima necesaria para hacerla aplicable.
+     Si la disposición no puede ser reformada, deberá ser eliminada de
+     esta Licencia Pública sin afectar la exigibilidad de los términos
+     y condiciones restantes.
+
+  c. No se podrá renunciar a ningún término o condición de esta
+     Licencia Pública, ni se consentirá ningún incumplimiento, a menos
+     que se acuerde expresamente con el Licenciante.
+
+  d. Nada en esta Licencia Pública constituye ni puede ser interpretado
+     como una limitación o una renuncia a los privilegios e inmunidades
+     que aplican al Licenciante o a Usted, incluyendo aquellos surgidos
+     a partir de procesos legales de cualquier jurisdicción o
+     autoridad.
+
+
+=======================================================================
+
+Creative Commons no es una parte en sus licencias públicas. No
+obstante, Creative Commons puede optar por aplicar una de sus licencias
+públicas al material que publica y en estos casos debe ser considerado
+como el “Licenciante”. El texto de las licencias públicas de Creative
+Commons está dedicado al dominio público bajo una licencia CC0 de
+Dedicación al Dominio Público. Excepto con el propósito limitado de
+indicar que el material se comparte bajo una licencia pública de
+Creative Commons o según lo permitido por las políticas de Creative
+Commons publicadas en creativecommons.org/policies, Creative Commons no
+autoriza el uso de la marca “Creative Commons” o cualquier otra marca o
+logotipo de Creative Commons sin su consentimiento previo por escrito,
+incluso, de manera enunciativa y no taxativa, en relación con
+modificaciones no autorizadas de cualquiera de sus licencias públicas o
+de cualquier otro acuerdo, arreglo o convenio relativos al uso de
+Material Licenciado. Para evitar cualquier duda, este párrafo no forma
+parte de las licencias públicas.
+
+Puede contactarse con Creative Commons en creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Web de la Comunidad Meshtastic en Español
 
-[![GitHub License][github-license-shield]](LICENSE)
 [![GitHub Actions Workflow Status][github-workflow-status-deploy-shield]][github-workflow-status-deploy]
 [![GitHub commit activity][commit-activity-shield]][commit-activity]
 [![GitHub contributors][github-contributors-shield]][github-contributors]
@@ -37,19 +36,14 @@ Y visitar la web en construcción:
 
 ## 📃 Licencia
 
-Esta obra está bajo una
-[Licencia Creative Commons Atribución-CompartirIgual 4.0 Internacional][cc-by-sa].
+La documentación e información de la Comunidad Meshtastic España en las carpetas `docs/`, `static/`, `src/` y `blog/` está licenciada bajo una [licencia CC BY-SA](LICENSE).
 
-[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
+Todo el resto del código en este repositorio está licenciado bajo la [licencia MIT](LICENSE-CODE).
 
 ---
 
 ¡Gracias por colaborar con Meshtastic en español! 🇪🇸
 
-[cc-by-sa]: https://creativecommons.org/licenses/by-sa/4.0/deed.es
-[cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
-[cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
-[github-license-shield]: https://img.shields.io/github/license/meshtastic-es-community/meshtastic-es-community.github.io
 [github-workflow-status-deploy-shield]: https://img.shields.io/github/actions/workflow/status/meshtastic-es-community/meshtastic-es-community.github.io/deploy.yml
 [github-workflow-status-deploy]: https://github.com/meshtastic-es-community/meshtastic-es-community.github.io/actions/workflows/deploy.yml
 [github-contributors-shield]: https://img.shields.io/github/contributors/meshtastic-es-community/meshtastic-es-community.github.io

--- a/docs/configuracion_avanzada/_category_.json
+++ b/docs/configuracion_avanzada/_category_.json
@@ -2,6 +2,7 @@
   "label": "Configuración Avanzada",
   "position": 5,
   "link": {
+    "slug": "configuracion-avanzada",
     "type": "generated-index",
     "description": "Aquí encontrarás información más en profundidad sobre las configuraciones."
   }

--- a/docs/guias/_category_.json
+++ b/docs/guias/_category_.json
@@ -2,6 +2,7 @@
   "label": "Guías",
   "position": 4,
   "link": {
+    "slug": "guias",
     "type": "generated-index",
     "description": "Aquí encontrarás guías sobre diversos temas."
   }


### PR DESCRIPTION
Por algún motivo, Github no detectaba la licencia correctamente. Y he visto en el repositorio https://github.com/github/docs que tienen 2 licencias. Una para la documentación y recursos, y otra para el resto del código. He hecho lo mismo, CC BY-SA para documentación y recursos, MIT para el resto del código.

También he "forzado" la url de las categorías para que no aparezca `docs/category/guias` sino `docs/guias`. Creo que queda mejor.