### PR TITLE
Añadir el canal de Málaga y ordenar por orden alfabético

### DIFF
--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -195,9 +195,9 @@ export const regionConfigs = [
     {"name": "Cantabria", "channel": "Cantabria", "base64": "Cg8aCUNhbnRhYnJpYSgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Cádiz", "channel": "Cadiz", "base64": "CgsaBUNhZGl6KAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
     {"name": "Euskadi", "channel": "Euskadi", "base64": "Cg0aB0V1c2thZGkoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
-    {"name": "La Rioja", "channel": "LaRioja", "base64": "Cg0aB0xhUmlvamEoATABEhIIATgDQARIAVAbaAHABgHIBgE"}
+    {"name": "La Rioja", "channel": "LaRioja", "base64": "Cg0aB0xhUmlvamEoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
     {"name": "Madrid", "channel": "Madrid", "base64": "CgwaBk1hZHJpZCgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
-    {"name": "Málaga", "channel": "Malaga", "base64": "ChESAQEaBk1hbGFnYSgBMAE6ABIPCAE4A0AFSAFQG2gByAYB"}
+    {"name": "Málaga", "channel": "Malaga", "base64": "ChESAQEaBk1hbGFnYSgBMAE6ABIPCAE4A0AFSAFQG2gByAYB"},
     {"name": "Navarra", "channel": "Navarra", "base64": "Cg0aB05hdmFycmEoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
     {"name": "Salamanca", "channel": "Salamanca", "base64": "Cg8aCVNhbGFtYW5jYSgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Toledo", "channel": "Toledo", "base64": "CgwaBlRvbGVkbygBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},

--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -190,19 +190,19 @@ Código QR para añadir los canales principales. Escanea con la cámara dentro d
 ### Canales por provincias 🗺️
 
 export const regionConfigs = [
-    {"name": "Madrid", "channel": "Madrid", "base64": "CgwaBk1hZHJpZCgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Alicante", "channel": "Alicante", "base64": "Cg4aCEFsaWNhbnRlKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
-    {"name": "Cádiz", "channel": "Cadiz", "base64": "CgsaBUNhZGl6KAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
+    {"name": "Asturias", "channel": "Asturias", "base64": "Cg4aCEFzdHVyaWFzKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
     {"name": "Cantabria", "channel": "Cantabria", "base64": "Cg8aCUNhbnRhYnJpYSgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
+    {"name": "Cádiz", "channel": "Cadiz", "base64": "CgsaBUNhZGl6KAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
+    {"name": "Euskadi", "channel": "Euskadi", "base64": "Cg0aB0V1c2thZGkoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
+    {"name": "La Rioja", "channel": "LaRioja", "base64": "Cg0aB0xhUmlvamEoATABEhIIATgDQARIAVAbaAHABgHIBgE"}
+    {"name": "Madrid", "channel": "Madrid", "base64": "CgwaBk1hZHJpZCgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
+    {"name": "Málaga", "channel": "Malaga", "base64": "ChESAQEaBk1hbGFnYSgBMAE6ABIPCAE4A0AFSAFQG2gByAYB"}
+    {"name": "Navarra", "channel": "Navarra", "base64": "Cg0aB05hdmFycmEoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
+    {"name": "Salamanca", "channel": "Salamanca", "base64": "Cg8aCVNhbGFtYW5jYSgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Toledo", "channel": "Toledo", "base64": "CgwaBlRvbGVkbygBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Valencia", "channel": "Valencia", "base64": "Cg4aCFZhbGVuY2lhKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
-    {"name": "Asturias", "channel": "Asturias", "base64": "Cg4aCEFzdHVyaWFzKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
-    {"name": "Salamanca", "channel": "Salamanca", "base64": "Cg8aCVNhbGFtYW5jYSgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Zaragoza", "channel": "Zaragoza", "base64": "Cg4aCFphcmFnb3phKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
-    {"name": "Euskadi", "channel": "Euskadi", "base64": "Cg0aB0V1c2thZGkoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
-    {"name": "Navarra", "channel": "Navarra", "base64": "Cg0aB05hdmFycmEoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
-    {"name": "La Rioja", "channel": "LaRioja", "base64": "Cg0aB0xhUmlvamEoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
-    {"name": "Málaga", "channel": "Malaga", "base64": "ChESAQEaBk1hbGFnYSgBMAE6ABIPCAE4A0AFSAFQG2gByAYB"}
 ]
 
 export const QRsProvinciales = () => {

--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -201,7 +201,8 @@ export const regionConfigs = [
     {"name": "Zaragoza", "channel": "Zaragoza", "base64": "Cg4aCFphcmFnb3phKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
     {"name": "Euskadi", "channel": "Euskadi", "base64": "Cg0aB0V1c2thZGkoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
     {"name": "Navarra", "channel": "Navarra", "base64": "Cg0aB05hdmFycmEoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
-    {"name": "La Rioja", "channel": "LaRioja", "base64": "Cg0aB0xhUmlvamEoATABEhIIATgDQARIAVAbaAHABgHIBgE"}
+    {"name": "La Rioja", "channel": "LaRioja", "base64": "Cg0aB0xhUmlvamEoATABEhIIATgDQARIAVAbaAHABgHIBgE"},
+    {"name": "Málaga", "channel": "Malaga", "base64": "ChESAQEaBk1hbGFnYSgBMAE6ABIPCAE4A0AFSAFQG2gByAYB"}
 ]
 
 export const QRsProvinciales = () => {

--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -202,7 +202,7 @@ export const regionConfigs = [
     {"name": "Salamanca", "channel": "Salamanca", "base64": "Cg8aCVNhbGFtYW5jYSgBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Toledo", "channel": "Toledo", "base64": "CgwaBlRvbGVkbygBMAESEggBOANABEgBUBtoAcAGAcgGAQ"},
     {"name": "Valencia", "channel": "Valencia", "base64": "Cg4aCFZhbGVuY2lhKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
-    {"name": "Zaragoza", "channel": "Zaragoza", "base64": "Cg4aCFphcmFnb3phKAEwARISCAE4A0AESAFQG2gBwAYByAYB"},
+    {"name": "Zaragoza", "channel": "Zaragoza", "base64": "Cg4aCFphcmFnb3phKAEwARISCAE4A0AESAFQG2gBwAYByAYB"}
 ]
 
 export const QRsProvinciales = () => {


### PR DESCRIPTION
Este PR añade a la documentación el canal existente de Málaga al listado de canales por provincia y ordena el listado por orden alfabético