### PR TITLE
Cambio de mapa en la página de mapas

### DIFF
--- a/docs/mapas.md
+++ b/docs/mapas.md
@@ -11,9 +11,16 @@ Aquí encontrarás enlaces útiles para visualizar la red y herramientas de la c
 
 ## 🌐 Mapa principal {#mapa-principal}
 
-🔗 https://mapa.meshtastic.es
+🔗 Mapa completo disponible [aqui](https://mapa.meshtastic.es).
 
-Visualiza todos los nodos activos, su ubicación aproximada y su alcance. Ideal para comprobar la cobertura de la red Meshtastic en tiempo real.
+<iframe
+  src="https://mapa.meshtastic.es"
+  width="100%"
+  height="500"
+  style={{border: 'none', borderRadius: '8px'}}
+  loading="lazy"
+  title="Mapa interactivo de nodos Meshtastic España"
+/>
 
 ---
 


### PR DESCRIPTION
Nuevo mapa para meshtastic España que se alimenta directamente de los datos de meshview. Incrustrado directamente en la sección de mapas.

Imagen de cómo queda:

<img width="1460" height="726" alt="Captura de pantalla 2026-04-13 a las 11 58 58" src="https://github.com/user-attachments/assets/64134f0c-e9ac-4ad6-8de6-197d3f21202d" />

