### PR TITLE
Reorganizacion de Pruebas y Generador de QRs

### DIFF
--- a/blog/2026-03-13-multiples-tests-sfnarrow.md
+++ b/blog/2026-03-13-multiples-tests-sfnarrow.md
@@ -62,21 +62,31 @@ condiciones.
 
 - _Bandwidth_: `125`
 - _Spread Factor_: `7`
-- _Coding Rate_: `5`
+- _Coding Rate_: `8`
 - _Frequency slot_: `2`
 - _Frequency override_: `869.5875`
 - [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow+-+Prueba+3)
 
 #### Prueba 4 - del 25/04/2026 al 01/05/2026
 
-- _Bandwidth_: `125`
-- _Spread Factor_: `7`
-- _Coding Rate_: `5`
-- _Frequency slot_: `1`
-- _Frequency override_: `869.4625`
-- [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow+-+Prueba+4)
+- _Preset_: **ShortSlow**
+- [Enlace al QR de configuración](/docs/generador-configuracion?preset=ShortSlow)
 
 #### Prueba 5 - del 02/05/2026 al 08/05/2026
+
+- _Preset_: **ShortFast**
+- [Enlace al QR de configuración](/docs/generador-configuracion?preset=ShortFast)
+
+#### Prueba 6 - del 09/05/2026 al 15/05/2026 (Repeticion de la Prueba 1)
+
+- _Bandwidth_: `62`
+- _Spread Factor_: `7`
+- _Coding Rate_: `5`
+- _Frequency slot_: `4`
+- _Frequency override_: `869.618`
+- [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow+-+Prueba+1)
+
+#### Prueba 7 - del 16/05/2026 al 22/05/2026
 
 - _Bandwidth_: `62`
 - _Spread Factor_: `6`
@@ -85,23 +95,25 @@ condiciones.
 - _Frequency override_: `869.618`
 - [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow+-+Prueba+5)
 
-#### Prueba 6 - del 09/05/2026 al 15/05/2026
+#### Volvemos - del 23/05/2026 en adelante
 
-- Propuesta de probar el preset ShortFast
+- Volvemos temporalmente al _preset_ **MediumFast**.
+- Valoramos los datos obtenidos para tomar una decisión.
+- [Enlace al QR de configuración](/docs/generador-configuracion?preset=MediumFast)
 
 :::info
 
-Ojo! los firmwares actuales (tanto la beta "estable" 2.7.15 como la última alpha 2.7.20) no tienen soporte para el Spreading Factor 6.
-Ademas los chips LoRa antiguos, tales como el SX1276 no son compatibles, por lo que nodos antiguos como el Heltec V2 no son compatibles.
-Antes de la prueba ofreceremos en caso necesario un firmware con soporte para flashear en los nodos compatibles.
+¡Ojo! Los firmwares oficiales actuales (tanto la beta "estable" 2.7.15 como la última alpha 2.7.22) no tienen soporte para el Spreading Factor 6 ni para anchos de banda inferiores a 125kHz en algunos casos. Además, los chips LoRa antiguos, como el SX1276, no son compatibles con SF6, por lo que nodos antiguos como el Heltec V2 no podrán participar en esa prueba específica.
+
+Para participar en los tests SFNarrow, es necesario utilizar compilaciones personalizadas con el soporte desbloqueado:
+
+- **[Firmware v2.7.15-custom (Recomendado para la mayoría de nodos de dificil acceso)](https://github.com/meshtastic-es-community/sfnarrow-firmware/actions/runs/23066767401#artifacts)**
+
+- **[Firmware v2.7.22-custom (Recomendado para Heltec V4 y similares)](https://github.com/meshtastic-es-community/sfnarrow-firmware/actions/runs/24403927815#artifacts)**
+
+Esperamos que estos cambios se incluyan de forma oficial en la siguiente version del firmware. El Pull Request ya mergeado **[PR](https://github.com/meshtastic/firmware/pull/10160)**.
 
 :::
-
-#### Volvemos - del 23/05/2026 en adelante
-
-- Volvemos al _preset_ **MediumFast**.
-- Valoramos los datos obtenidos para tomar una decisión.
-- [Enlace al QR de configuración](/docs/generador-configuracion?preset=MediumFast)
 
 ### 📊 Recopilación de datos{#recopilacion-datos}
 

--- a/src/components/MeshtasticConfigGenerator/config.ts
+++ b/src/components/MeshtasticConfigGenerator/config.ts
@@ -22,6 +22,23 @@ export const PRESETS: Presets = {
       region: DEFAULT_REGION,
     },
   },
+  'ShortSlow': {
+    loraConfig: {
+      usePreset: true,
+      modemPreset: ModemPreset.SHORT_SLOW,
+      region: DEFAULT_REGION,
+      overrideFrequency: 869.525, //Al venir de las pruebas lo incluyo por si alguien lo tiene mal
+    },
+  },
+  'ShortFast': {
+    loraConfig: {
+      usePreset: true,
+      modemPreset: ModemPreset.SHORT_FAST,
+      region: DEFAULT_REGION,
+      overrideFrequency: 869.525, //Al venir de las pruebas lo incluyo por si alguien lo tiene mal
+    },
+  },
+
   'SFNarrow - Prueba 1': {
     label: 'BW 62, SF 7, CR 5, 869.618 MHz',
     overrideChannelName: 'SFNarrow',
@@ -48,19 +65,19 @@ export const PRESETS: Presets = {
     },
   },
   'SFNarrow - Prueba 3': {
-    label: 'BW 125, SF 7, CR 5, 869.5875 MHz',
+    label: 'BW 125, SF 7, CR 8, 869.5875 MHz',
     overrideChannelName: 'SFNarrow',
     loraConfig: {
       usePreset: false,
       bandwidth: 125,
       spreadFactor: 7,
-      codingRate: 5,
+      codingRate: 8,
       region: DEFAULT_REGION,
       frecuencySlot: 2,
       overrideFrequency: 869.5875,
     },
   },
-  'SFNarrow - Prueba 4': {
+  'Narrow 125kHz Slot 1': {
     label: 'BW 125, SF 7, CR 5, 869.4625 MHz',
     overrideChannelName: 'SFNarrow',
     loraConfig: {
@@ -73,7 +90,7 @@ export const PRESETS: Presets = {
       overrideFrequency: 869.4625,
     },
   },
-  'SFNarrow - Prueba 5': {
+  'SFNarrow - Prueba 7': {
     label: 'BW 62, SF 6, CR 5, 869.618 MHz',
     overrideChannelName: 'SFNarrow',
     loraConfig: {
@@ -85,6 +102,34 @@ export const PRESETS: Presets = {
       overrideFrequency: 869.618,
     },
   },
+  //Con el PR mergeado incluyo estos dos por si nos apetece probarlos en algun momento
+  'ShortPlus': {
+    label: 'BW 250kHz, SF6, CR5, 869.525MHz',
+    overrideChannelName: 'ShortPlus',
+    loraConfig: {
+      usePreset: false,
+      bandwidth: 250,
+      spreadFactor: 6,
+      codingRate: 5,
+      region: DEFAULT_REGION,
+      frecuencySlot: 1,
+      overrideFrequency: 869.525,
+    },
+  },
+  'ShortProMax': {
+    label: 'BW 250kHz, SF5, CR5, 869.525MHz',
+    overrideChannelName: 'ShortProMax',
+    loraConfig: {
+      usePreset: false,
+      bandwidth: 250,
+      spreadFactor: 5,
+      codingRate: 5,
+      region: DEFAULT_REGION,
+      frecuencySlot: 1,
+      overrideFrequency: 869.525,
+    },
+  },
+
 };
 
 // Radio configurations

--- a/src/components/MeshtasticConfigGenerator/index.tsx
+++ b/src/components/MeshtasticConfigGenerator/index.tsx
@@ -22,6 +22,8 @@ function pskToBase64(psk: Uint8Array | undefined): string {
 function generateConfigUrl(
   presetName: keyof typeof PRESETS,
   includeIberia: boolean,
+  includeTest: boolean,
+  includeBots: boolean,
   regionalChannel: string | null,
   selectedRadio: string | null
 ): { url: string; loraConfig: LoRaConfig; channels: { name: string; psk: string }[] } {
@@ -51,6 +53,30 @@ function generateConfigUrl(
       downlinkEnabled: true,
     });
     channelInfo.push({ name: 'Iberia', psk: pskToBase64(DEFAULT_PSK) });
+  }
+
+  // Add Test channel if requested
+  if (includeTest) {
+    const testKey = new Uint8Array([2]);
+    channels.push({
+      psk: testKey,
+      name: 'Test',
+      uplinkEnabled: true,
+      downlinkEnabled: true,
+    });
+    channelInfo.push({ name: 'Test', psk: pskToBase64(testKey) });
+  }
+
+  // Add Bots channel if requested
+  if (includeBots) {
+    const botsKey = new Uint8Array([2]);
+    channels.push({
+      psk: botsKey,
+      name: 'Bots',
+      uplinkEnabled: true,
+      downlinkEnabled: true,
+    });
+    channelInfo.push({ name: 'Bots', psk: pskToBase64(botsKey) });
   }
 
   // Add regional channel if selected
@@ -120,10 +146,24 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
     if (radio) {
       setSelectedRadio(radio);
     }
+
+    // Parse Test
+    const test = params.get('test');
+    if (test !== null) {
+      setIncludeTest(test === 'true');
+    }
+
+    // Parse Bots
+    const bots = params.get('bots');
+    if (bots !== null) {
+      setIncludeBots(bots === 'true');
+    }
   }, []);
 
   const [selectedPreset, setSelectedPreset] = useState<keyof typeof PRESETS>(Object.keys(PRESETS)[0] as keyof typeof PRESETS);
   const [includeIberia, setIncludeIberia] = useState(false);
+  const [includeTest, setIncludeTest] = useState(false);
+  const [includeBots, setIncludeBots] = useState(false);
   const [includeRegional, setIncludeRegional] = useState(false);
   const [selectedRegion, setSelectedRegion] = useState<string>(Object.values(REGION_CONFIGS)[0].channel);
   const [selectedRadio, setSelectedRadio] = useState<string | null>(null);
@@ -137,6 +177,8 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
     const params = new URLSearchParams();
     params.set('preset', selectedPreset);
     params.set('iberia', includeIberia.toString());
+    params.set('test', includeTest.toString());
+    params.set('bots', includeBots.toString());
     params.set('regional', includeRegional.toString());
     if (includeRegional) {
       params.set('region', selectedRegion);
@@ -156,6 +198,8 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
     const params = new URLSearchParams();
     params.set('preset', selectedPreset);
     params.set('iberia', includeIberia.toString());
+    params.set('test', includeTest.toString());
+    params.set('bots', includeBots.toString());
     params.set('regional', includeRegional.toString());
     if (includeRegional) {
       params.set('region', selectedRegion);
@@ -172,10 +216,12 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
     return generateConfigUrl(
       selectedPreset,
       includeIberia,
+      includeTest,
+      includeBots,
       includeRegional ? selectedRegion : null,
       selectedRadio
     );
-  }, [selectedPreset, includeIberia, includeRegional, selectedRegion, selectedRadio]);
+  }, [selectedPreset, includeIberia, includeTest, includeBots, includeRegional, selectedRegion, selectedRadio]);
 
   return (
     <div className="meshtastic-config-generator">
@@ -300,6 +346,24 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
                 onChange={(e) => setIncludeIberia(e.target.checked)}
               />
               <span>Iberia</span>
+            </label>
+
+            <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: '8px' }}>
+              <input
+                type="checkbox"
+                checked={includeTest}
+                onChange={(e) => setIncludeTest(e.target.checked)}
+              />
+              <span>Test</span>
+            </label>
+
+            <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: '8px' }}>
+              <input
+                type="checkbox"
+                checked={includeBots}
+                onChange={(e) => setIncludeBots(e.target.checked)}
+              />
+              <span>Bots</span>
             </label>
             
             <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: '8px' }}>


### PR DESCRIPTION
- Cambio de Coding Rate 8 en la Prueba 3
- Añadir las pruebas de ShortSlow, ShortFast y el rerun de la P1 al calendario
- Incluir enlaces a los firmware compilados para quien tenga que flashear nodos con tiempo.
- Incluir tambien porsiaca los presets ShortPlus y ShortProMax en el generador por si se quieren probar, ya que esta mergeada la PR de los Spreading Factors.

⚠️La parte de los QRs esta vibecodeada casi entera(Gemini 3.1 Flash en OpenClaw) so here be dragons😂, pero lo he comprobado, lo que he cambiado es añadir el override frequency a los dos por si acaso alguien al venir de las pruebas se le queda mal puesto.