### PR TITLE
fix(configurator): add missing includeTest and includeBots to dependency arrays

### DIFF
--- a/src/components/MeshtasticConfigGenerator/index.tsx
+++ b/src/components/MeshtasticConfigGenerator/index.tsx
@@ -189,7 +189,7 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
     
     const baseUrl = window.location.origin + window.location.pathname;
     return `${baseUrl}?${params.toString()}`;
-  }, [selectedPreset, includeIberia, includeRegional, selectedRegion, selectedRadio]);
+  }, [selectedPreset, includeIberia, includeTest, includeBots, includeRegional, selectedRegion, selectedRadio]);
 
   // Update URL in real-time without page reload
   useEffect(() => {
@@ -210,7 +210,7 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
     
     const newUrl = `${window.location.pathname}?${params.toString()}`;
     window.history.replaceState({}, '', newUrl);
-  }, [selectedPreset, includeIberia, includeRegional, selectedRegion, selectedRadio]);
+  }, [selectedPreset, includeIberia, includeTest, includeBots, includeRegional, selectedRegion, selectedRadio]);
 
   const { url: configUrl, loraConfig, channels } = useMemo(() => {
     return generateConfigUrl(


### PR DESCRIPTION
# Motivation
When using the Configuration Generator and checking the "Test" or "Bots" checkboxes, the QR code and internal config were updated correctly. But if you clicked "Share configuration", the copied URL didn't reflect those two channels. The browser address bar had the same issue, it wouldn't update when toggling Test or Bots.

So if you shared that URL with someone, they'd get a different configuration than what you had on screen.

<img width="1165" height="889" alt="image" src="https://github.com/user-attachments/assets/72bfc6dd-9d6e-4a9f-9f16-7c9349d718ee" />


# Fix
The useMemo that generates the shareable URL and the useEffect that syncs the browser address bar both had includeTest and includeBots missing from their dependency arrays. Just added them.