### PR TITLE
Reordenar un poco `userPrefs` para una mejor comprensión.

### DIFF
--- a/docs/configuracion-avanzada/preferencias-de-usuario.mdx
+++ b/docs/configuracion-avanzada/preferencias-de-usuario.mdx
@@ -9,15 +9,19 @@ import TabItem from "@theme/TabItem";
 
 # Preferencias de usuario :mdi-tune:
 
-Cuando flasheas un nodo de Meshtastic con el _firmware_ oficial, este se inicia con una configuración genérica (_factory defaults_). Si estás desplegando repetidores de montaña, nodos fijos en tu ciudad o varios nodos para un grupo, tener que conectarte uno a uno por Bluetooth o cable para configurarlos es un proceso lento.
+Cuando flasheas un nodo de Meshtastic con el _firmware_ oficial, arranca con una configuración genérica
+(_factory defaults_). Si vas a preparar varios nodos iguales, nodos fijos o equipos que no quieres configurar uno a uno
+por Bluetooth o cable, puedes ahorrar trabajo compilando el _firmware_ con valores por defecto propios.
 
-Afortunadamente, el _firmware_ de Meshtastic permite definir tus propios **valores preconfigurados** (o _Custom Defaults_) directamente durante la compilación. De este modo, al flashear el nodo por primera vez o al realizar un restablecimiento de fábrica, este adoptará automáticamente los parámetros que hayas preestablecido.
+Meshtastic permite hacerlo mediante el archivo `userPrefs.jsonc`. Los valores que definas ahí se aplicarán en el primer arranque del nodo o después de un restablecimiento de fábrica.
 
-Esta guía detalla el proceso basándose en la [documentación de desarrollo de Meshtastic](https://meshtastic.org/docs/development/firmware/build/).
+Esta guía resume el flujo práctico y deja al final una referencia de los parámetros más útiles. Está basada en la
+[documentación de desarrollo de Meshtastic](https://meshtastic.org/docs/development/firmware/build/).
 
 :::warning Aviso de seguridad
 
-Como se puede ver en esta guía, existen parámetros cuya configuración puede suponer un **problema de seguridad**, como por ejemplo las claves públicas de administración remota. Un _firmware_ manipulado podría incluir claves de un tercero, otorgándole control total sobre tu nodo sin tu conocimiento.
+Algunas preferencias afectan directamente a la seguridad del nodo. Por ejemplo, un _firmware_ manipulado podría incluir
+claves públicas de administración remota de un tercero y darle control sobre tu nodo sin que lo sepas.
 
 **Se recomienda no instalar _firmwares_ de origen desconocido o de fuentes en las que no confíes.** Compila siempre tu propio _firmware_ a partir del código fuente oficial.
 
@@ -27,19 +31,22 @@ Como se puede ver en esta guía, existen parámetros cuya configuración puede s
 
 ## 1. Clonar el repositorio de Meshtastic :mdi-git:
 
-El primer paso es obtener el código fuente del [_firmware_ de Meshtastic](https://github.com/meshtastic/firmware) en tu equipo, ya sea clonando el repositorio o descargando el ZIP:
+El primer paso es obtener el código fuente del [_firmware_ de Meshtastic](https://github.com/meshtastic/firmware) en tu equipo:
 
 ```bash
 git clone https://github.com/meshtastic/firmware.git
 cd firmware
+git submodule update --init
 ```
 
 :::tip
 
-Se recomienda trabajar sobre la etiqueta de la versión que desees compilar, por ejemplo `v2.7.15.567b8ea` o `v2.7.23.b246bcd`. Puedes ver todas las versiones [aquí](https://github.com/meshtastic/firmware/tags).
+Se recomienda trabajar sobre la etiqueta de la versión que desees compilar. Puedes ver todas las versiones publicadas en
+la [lista de etiquetas del repositorio](https://github.com/meshtastic/firmware/tags).
 
 ```bash
-git checkout v2.7.15.567b8ea
+git checkout vX.Y.Z.hash
+git submodule update --init
 ```
 
 :::
@@ -48,7 +55,8 @@ git checkout v2.7.15.567b8ea
 
 ## 2. Configurar las preferencias en `userPrefs.jsonc` :mdi-file-code:
 
-En la raíz del proyecto clonado encontrarás el archivo `userPrefs.jsonc`. Este fichero utiliza la sintaxis JSON con comentarios (`.jsonc`) y sirve como plantilla para definir las variables por defecto que se inyectarán en el _firmware_ durante la compilación.
+En la raíz del proyecto clonado encontrarás el archivo `userPrefs.jsonc`. Este fichero usa JSON con comentarios
+(`.jsonc`) y sirve para definir los valores por defecto que se incluirán en el _firmware_ durante la compilación.
 
 Para personalizar la configuración, abre el archivo con tu editor preferido (como VSCode) y descomenta/modifica las líneas necesarias.
 
@@ -57,222 +65,14 @@ Para personalizar la configuración, abre el archivo con tu editor preferido (co
 - Todos los valores en `userPrefs.jsonc` son **cadenas de texto** (entre comillas), incluso los números y booleanos.
 - Las líneas que empiezan por `//` están comentadas y se ignoran durante la compilación.
 - La mayoría de preferencias se aplican únicamente en el **primer arranque** o tras un **restablecimiento de fábrica**.
+  Si el nodo ya estaba configurado, borra la configuración antes de probar estos valores.
 
 :::
 
-### Qué NO se puede configurar con `userPrefs` :mdi-close-circle-outline: {#limitaciones}
+### Ejemplo base para España :mdi-map-marker: {#ejemplo}
 
-Antes de empezar, es importante tener claro qué **no** es posible definir a través de este fichero:
-
-- **No se pueden definir _presets_ de LoRa personalizados.** Solo puedes elegir entre los _presets_ predefinidos de la tabla que verás más abajo. Si necesitas valores personalizados de ancho de banda, _spreading factor_ o _coding rate_, tendrás que configurarlos en tiempo de ejecución con la CLI o la app móvil.
-- **No se pueden inyectar claves privadas.** Las claves de administración remota (`USERPREFS_USE_ADMIN_KEY_*`) corresponden siempre a la **clave pública** del nodo administrador, nunca a una clave privada.
-- **Los roles `ROUTER`, `ROUTER_LATE` y `LOST_AND_FOUND` están bloqueados.** Aunque los definas en `userPrefs`, el _firmware_ los ignorará y aplicará el rol `CLIENT` por defecto.
-- **Solo se pueden preconfigurar hasta 3 canales** (índices 0, 1 y 2), aunque el protocolo admite hasta 8.
-
-### Qué se puede configurar :mdi-check-circle-outline: {#que-se-puede-configurar}
-
-<div className="clean-details">
-
-<details>
-<summary><strong>Identidad del nodo</strong> :mdi-card-account-details-outline:</summary>
-
-| Parámetro                           | Descripción                                                          |
-|:------------------------------------|:---------------------------------------------------------------------|
-| `USERPREFS_CONFIG_OWNER_LONG_NAME`  | Nombre largo del nodo, el que aparece en la lista de nodos.          |
-| `USERPREFS_CONFIG_OWNER_SHORT_NAME` | Nombre corto, de 3 a 4 caracteres (ej. `"NCM1"`).                    |
-| `USERPREFS_CONFIG_DEVICE_ROLE`      | Rol del nodo. Por defecto es `CLIENT` (ver tabla de roles abajo).    |
-| `USERPREFS_FIXED_BLUETOOTH`         | PIN numérico fijo para el emparejamiento Bluetooth (ej. `"914257"`). |
-
-**Roles disponibles:**
-
-| Rol                    | Valor                                               |
-|:-----------------------|:----------------------------------------------------|
-| Client _(por defecto)_ | `meshtastic_Config_DeviceConfig_Role_CLIENT`        |
-| Client Mute            | `meshtastic_Config_DeviceConfig_Role_CLIENT_MUTE`   |
-| Client Hidden          | `meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN` |
-| Tracker                | `meshtastic_Config_DeviceConfig_Role_TRACKER`       |
-| Sensor                 | `meshtastic_Config_DeviceConfig_Role_SENSOR`        |
-| TAK                    | `meshtastic_Config_DeviceConfig_Role_TAK`           |
-| TAK Tracker            | `meshtastic_Config_DeviceConfig_Role_TAK_TRACKER`   |
-
-</details>
-
-<details>
-<summary><strong>LoRa y región</strong> :mdi-radio-tower:</summary>
-
-| Parámetro                           | Descripción                                                                 |
-|:------------------------------------|:----------------------------------------------------------------------------|
-| `USERPREFS_CONFIG_LORA_REGION`      | Banda de frecuencia de tu país/región.                                      |
-| `USERPREFS_LORACONFIG_MODEM_PRESET` | Preset de velocidad/alcance de radio (ver tabla de presets abajo).          |
-| `USERPREFS_LORACONFIG_CHANNEL_NUM`  | Slot de canal dentro de la banda (`0` = autoselección basada en el nombre). |
-| `USERPREFS_CONFIG_LORA_IGNORE_MQTT` | `true` para ignorar completamente los paquetes provenientes de MQTT.        |
-| `USERPREFS_LORA_TX_DISABLED`        | `1` para desactivar la transmisión LoRa (modo solo recepción).              |
-
-**Presets de módem disponibles:**
-
-| Preset                    | Valor                                                    |
-|:--------------------------|:---------------------------------------------------------|
-| Long Fast _(por defecto)_ | `meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST`     |
-| Long Moderate             | `meshtastic_Config_LoRaConfig_ModemPreset_LONG_MODERATE` |
-| Long Turbo                | `meshtastic_Config_LoRaConfig_ModemPreset_LONG_TURBO`    |
-| Medium Fast               | `meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST`   |
-| Medium Slow               | `meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_SLOW`   |
-| Short Fast                | `meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST`    |
-| Short Slow                | `meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW`    |
-| Short Turbo               | `meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO`   |
-| Lite Fast _(EU 866MHz)_   | `meshtastic_Config_LoRaConfig_ModemPreset_LITE_FAST`     |
-| Lite Slow _(EU 866MHz)_   | `meshtastic_Config_LoRaConfig_ModemPreset_LITE_SLOW`     |
-| Narrow Fast _(EU 868MHz)_ | `meshtastic_Config_LoRaConfig_ModemPreset_NARROW_FAST`   |
-| Narrow Slow _(EU 868MHz)_ | `meshtastic_Config_LoRaConfig_ModemPreset_NARROW_SLOW`   |
-
-**Códigos de región para España:**
-
-| Región        | Valor                                            |
-|:--------------|:-------------------------------------------------|
-| Europa 868MHz | `meshtastic_Config_LoRaConfig_RegionCode_EU_868` |
-| Europa 433MHz | `meshtastic_Config_LoRaConfig_RegionCode_EU_433` |
-
-</details>
-
-<details>
-<summary><strong>Canales</strong> :mdi-forum-outline:</summary>
-
-Se pueden preconfigurar hasta **3 canales** (índices 0, 1 y 2).
-
-| Parámetro                              | Descripción                                                                                                                        |
-|:---------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------|
-| `USERPREFS_CHANNELS_TO_WRITE`          | Número de canales a inicializar en el arranque (`1` a `3`).                                                                        |
-| `USERPREFS_CHANNEL_0_NAME`             | Nombre del canal (máx. 11 caracteres). Disponible también para `_1_` y `_2_`.                                                      |
-| `USERPREFS_CHANNEL_0_PSK`              | Clave precompartida. Usa `{ 0x01 }` para la clave pública por defecto, o un array de 32 bytes hexadecimales para un canal privado. |
-| `USERPREFS_CHANNEL_0_PRECISION`        | Precisión de ubicación para el canal (ej. `14` = alta, valores bajos = menor precisión).                                           |
-| `USERPREFS_CHANNEL_0_UPLINK_ENABLED`   | `true` o `false` — si el canal sube mensajes a MQTT.                                                                               |
-| `USERPREFS_CHANNEL_0_DOWNLINK_ENABLED` | `true` o `false` — si el canal descarga mensajes de MQTT.                                                                          |
-
-</details>
-
-<details>
-<summary><strong>Posición GPS fija</strong> :mdi-crosshairs-gps:</summary>
-
-Ideal para nodos estáticos (repetidores, nodos solares) que no tienen módulo GPS.
-
-| Parámetro                 | Descripción                                      |
-|:--------------------------|:-------------------------------------------------|
-| `USERPREFS_FIXED_GPS`     | `true` para activar la posición fija.            |
-| `USERPREFS_FIXED_GPS_LAT` | Latitud en formato decimal (ej. `"40.284297"`).  |
-| `USERPREFS_FIXED_GPS_LON` | Longitud en formato decimal (ej. `"-3.927447"`). |
-| `USERPREFS_FIXED_GPS_ALT` | Altitud en metros (ej. `"650"`). Opcional.       |
-
-:::warning
-
-Las coordenadas GPS fijas solo se aplican durante el **primer arranque** o justo después de un **restablecimiento de fábrica**. Si el dispositivo ya ha arrancado antes, no sobreescribirá las coordenadas almacenadas.
-
-:::
-
-</details>
-
-<details>
-<summary><strong>Administración remota</strong> :mdi-remote:</summary>
-
-Se pueden preconfigurar hasta 3 claves públicas de administración remota. Cuando otro nodo envíe un comando administrativo firmado con la clave privada correspondiente, este nodo lo aceptará.
-
-| Parámetro                   | Descripción                                                                  |
-|:----------------------------|:-----------------------------------------------------------------------------|
-| `USERPREFS_USE_ADMIN_KEY_0` | Clave pública principal del administrador (array de 32 bytes hexadecimales). |
-| `USERPREFS_USE_ADMIN_KEY_1` | Clave pública secundaria.                                                    |
-| `USERPREFS_USE_ADMIN_KEY_2` | Clave pública terciaria.                                                     |
-
-:::tip
-
-La clave que debes poner aquí es la **clave pública** (_public key_) de tu nodo administrador personal, formateada en hexadecimal byte a byte. **Nunca** introduzcas una clave privada.
-
-:::
-
-</details>
-
-<details>
-<summary><strong>Intervalos de posición y telemetría</strong> :mdi-timer-outline:</summary>
-
-| Parámetro                                          | Descripción                                                                                      |
-|:---------------------------------------------------|:-------------------------------------------------------------------------------------------------|
-| `USERPREFS_CONFIG_POSITION_BROADCAST_INTERVAL`     | Cada cuántos segundos se emite la posición (ej. `86400` = una vez al día).                       |
-| `USERPREFS_CONFIG_GPS_UPDATE_INTERVAL`             | Cada cuántos segundos se consulta el módulo GPS.                                                 |
-| `USERPREFS_CONFIG_SMART_POSITION_ENABLED`          | `true` o `false` — emite posición solo cuando el nodo se ha movido.                              |
-| `USERPREFS_CONFIG_GPS_MODE`                        | Modo del GPS. Usa `meshtastic_Config_PositionConfig_GpsMode_DISABLED` para apagarlo.             |
-| `USERPREFS_CONFIG_DEVICE_TELEM_UPDATE_INTERVAL`    | Intervalo de telemetría del dispositivo, en segundos.                                            |
-| `USERPREFS_CONFIG_ENV_TELEM_UPDATE_INTERVAL`       | Intervalo de telemetría ambiental (sensores), en segundos.                                       |
-| `USERPREFS_CONFIG_ENVIRONMENT_MEASUREMENT_ENABLED` | `1` para forzar lecturas de sensores (BMP280, etc.) y emisión por LoRa desde el primer arranque. |
-
-</details>
-
-<details>
-<summary><strong>MQTT</strong> :mdi-cloud-outline:</summary>
-
-| Parámetro                           | Descripción                                                                                    |
-|:------------------------------------|:-----------------------------------------------------------------------------------------------|
-| `USERPREFS_MQTT_ENABLED`            | `1` para activar el módulo MQTT.                                                               |
-| `USERPREFS_MQTT_ADDRESS`            | Dirección del broker (ej. `"'mqtt.meshtastic.es'"`). Ojo con las comillas simples adicionales. |
-| `USERPREFS_MQTT_USERNAME`           | Usuario MQTT.                                                                                  |
-| `USERPREFS_MQTT_PASSWORD`           | Contraseña MQTT.                                                                               |
-| `USERPREFS_MQTT_ENCRYPTION_ENABLED` | `true` para cifrar los paquetes enviados por MQTT.                                             |
-| `USERPREFS_MQTT_TLS_ENABLED`        | `true` o `false` para habilitar TLS.                                                           |
-| `USERPREFS_MQTT_ROOT_TOPIC`         | Tema raíz personalizado (ej. `"event/mi-evento"`).                                             |
-
-</details>
-
-<details>
-<summary><strong>WiFi (solo ESP32)</strong> :mdi-wifi:</summary>
-
-| Parámetro                             | Descripción                              |
-|:--------------------------------------|:-----------------------------------------|
-| `USERPREFS_NETWORK_WIFI_ENABLED`      | `true` para activar WiFi en el arranque. |
-| `USERPREFS_NETWORK_WIFI_SSID`         | Nombre de la red WiFi.                   |
-| `USERPREFS_NETWORK_WIFI_PSK`          | Contraseña WiFi.                         |
-| `USERPREFS_NETWORK_ENABLED_PROTOCOLS` | `1` para habilitar UDP mesh por red.     |
-| `USERPREFS_NETWORK_IPV6_ENABLED`      | `1` para habilitar IPv6.                 |
-
-</details>
-
-<details>
-<summary><strong>Branding OEM (pantalla de inicio personalizada)</strong> :mdi-monitor:</summary>
-
-Puedes sustituir el logo y texto de arranque de Meshtastic por uno personalizado de tu comunidad o grupo.
-
-| Parámetro                    | Descripción                                                                 |
-|:-----------------------------|:----------------------------------------------------------------------------|
-| `USERPREFS_OEM_TEXT`         | Texto personalizado en la pantalla de arranque (ej. `"Meshtastic España"`). |
-| `USERPREFS_OEM_FONT_SIZE`    | Tamaño de fuente (`0` = pequeño, `1` = mediano, `2` = grande).              |
-| `USERPREFS_OEM_IMAGE_WIDTH`  | Ancho del logo personalizado, en píxeles.                                   |
-| `USERPREFS_OEM_IMAGE_HEIGHT` | Alto del logo personalizado, en píxeles.                                    |
-| `USERPREFS_OEM_IMAGE_DATA`   | Datos de imagen como array de bytes XBM (ej. `{ 0x00, 0xFF, ... }`).        |
-
-</details>
-
-<details>
-<summary><strong>Notificaciones y zona horaria</strong> :mdi-bell-outline:</summary>
-
-| Parámetro                     | Descripción                                                                                                            |
-|:------------------------------|:-----------------------------------------------------------------------------------------------------------------------|
-| `USERPREFS_RINGTONE_RTTTL`    | Tono de notificación personalizado en [formato RTTTL](https://en.wikipedia.org/wiki/Ring_Tone_Text_Transfer_Language). |
-| `USERPREFS_RINGTONE_NAG_SECS` | Segundos antes de repetir la notificación de mensaje no leído (ej. `60`).                                              |
-| `USERPREFS_TZ_STRING`         | Zona horaria en formato POSIX. Para España peninsular: `"CET-1CEST,M3.5.0,M10.5.0/3"`. Para Canarias: `"WET0WEST,M3.5.0/1,M10.5.0"`. |
-
-</details>
-
-<details>
-<summary><strong>Modo evento</strong> :mdi-calendar-star:</summary>
-
-Configuraciones especiales para eventos con muchos nodos.
-
-| Parámetro                    | Descripción                                                                                                                                                                                                                        |
-|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `USERPREFS_EVENT_MODE`       | `1` para activar el modo evento. Aplica restricciones estrictas: limita saltos a 2, aumenta retardos, bloquea puertos no esenciales, degrada roles Router a Client, limita posición a 1 emisión cada 5 min y bloquea MQTT público. |
-| `USERPREFS_FIRMWARE_EDITION` | Etiqueta la edición del _firmware_ para que las apps (iOS/Android) muestren temas específicos del evento.                                                                                                                            |
-
-</details>
-
-</div>
-
-### Ejemplo completo para España :mdi-map-marker: {#ejemplo}
+Copia solo los valores que necesites y cambia los nombres, coordenadas y claves por los tuyos. Este ejemplo fija región
+EU 868, preset Long Fast, posición estática y zona horaria peninsular:
 
 ```json
 {
@@ -382,3 +182,241 @@ pio run -e nrf52_promicro_diy_tcxo -t upload
 Asegúrate de que el puerto serie de tu nodo no esté ocupado por otra aplicación (como un monitor serie o el flasheador web de Meshtastic en el navegador) antes de lanzar el comando de subida.
 
 :::
+
+---
+
+## 5. Comprobar que se han aplicado los valores :mdi-check:
+
+Después de flashear, enciende el nodo y revisa desde la app o la CLI que la configuración esperada se ha cargado correctamente.
+
+- Comprueba el nombre largo y el nombre corto del nodo.
+- Comprueba la región LoRa y el _preset_ de módem.
+- Si has definido posición fija, comprueba que aparece la latitud, longitud y altitud esperadas.
+- Si has añadido una clave de administración remota, comprueba que aparece en la sección de seguridad del nodo. Puedes
+  ampliar este punto en la [guía de administración remota](./administracion-remota.md).
+
+Si el nodo ya había arrancado antes con otra configuración, haz un **restablecimiento de fábrica** y vuelve a probar.
+Muchas preferencias de `userPrefs.jsonc` no sobreescriben valores ya guardados.
+
+---
+
+## 6. Referencia de preferencias disponibles :mdi-format-list-bulleted:
+
+### Qué NO se puede configurar con `userPrefs` :mdi-close-circle-outline: {#limitaciones}
+
+Antes de depender de este fichero, ten claras estas limitaciones:
+
+- **No se pueden definir _presets_ de LoRa personalizados.** Solo puedes elegir entre los _presets_ predefinidos de la
+  tabla que verás más abajo. Si necesitas valores personalizados de ancho de banda, _spreading factor_ o _coding rate_,
+  tendrás que configurarlos en tiempo de ejecución con la CLI o la app móvil.
+- **No se pueden inyectar claves privadas.** Las claves de administración remota (`USERPREFS_USE_ADMIN_KEY_*`)
+  corresponden siempre a la **clave pública** del nodo administrador, nunca a una clave privada.
+- **Algunos roles están restringidos por el _firmware_.** En las versiones actuales, la familia `ROUTER`, `REPEATER` y
+  `LOST_AND_FOUND` no se puede forzar desde `userPrefs`. Comprueba el `userPrefs.jsonc` de la versión exacta que vayas a
+  compilar, porque esta lista puede cambiar.
+- **Solo se pueden preconfigurar hasta 3 canales** (índices 0, 1 y 2), aunque el protocolo admite hasta 8.
+
+### Qué se puede configurar :mdi-check-circle-outline: {#que-se-puede-configurar}
+
+<div className="clean-details">
+
+<details>
+<summary><strong>Identidad del nodo</strong> :mdi-card-account-details-outline:</summary>
+
+| Parámetro                           | Descripción                                                          |
+|:------------------------------------|:---------------------------------------------------------------------|
+| `USERPREFS_CONFIG_OWNER_LONG_NAME`  | Nombre largo del nodo, el que aparece en la lista de nodos.          |
+| `USERPREFS_CONFIG_OWNER_SHORT_NAME` | Nombre corto, de 3 a 4 caracteres (ej. `"NCM1"`).                    |
+| `USERPREFS_CONFIG_DEVICE_ROLE`      | Rol del nodo. Por defecto es `CLIENT` (ver tabla de roles abajo).    |
+| `USERPREFS_FIXED_BLUETOOTH`         | PIN numérico fijo para el emparejamiento Bluetooth (ej. `"914257"`). |
+
+**Roles disponibles:**
+
+| Rol                    | Valor                                               |
+|:-----------------------|:----------------------------------------------------|
+| Client _(por defecto)_ | `meshtastic_Config_DeviceConfig_Role_CLIENT`        |
+| Client Mute            | `meshtastic_Config_DeviceConfig_Role_CLIENT_MUTE`   |
+| Client Hidden          | `meshtastic_Config_DeviceConfig_Role_CLIENT_HIDDEN` |
+| Tracker                | `meshtastic_Config_DeviceConfig_Role_TRACKER`       |
+| Sensor                 | `meshtastic_Config_DeviceConfig_Role_SENSOR`        |
+| TAK                    | `meshtastic_Config_DeviceConfig_Role_TAK`           |
+| TAK Tracker            | `meshtastic_Config_DeviceConfig_Role_TAK_TRACKER`   |
+
+</details>
+
+<details>
+<summary><strong>LoRa y región</strong> :mdi-radio-tower:</summary>
+
+| Parámetro                           | Descripción                                                                 |
+|:------------------------------------|:----------------------------------------------------------------------------|
+| `USERPREFS_CONFIG_LORA_REGION`      | Banda de frecuencia de tu país/región.                                      |
+| `USERPREFS_LORACONFIG_MODEM_PRESET` | Preset de velocidad/alcance de radio (ver tabla de presets abajo).          |
+| `USERPREFS_LORACONFIG_CHANNEL_NUM`  | Slot de canal dentro de la banda (`0` = autoselección basada en el nombre). |
+| `USERPREFS_CONFIG_LORA_IGNORE_MQTT` | `true` para ignorar completamente los paquetes provenientes de MQTT.        |
+| `USERPREFS_LORA_TX_DISABLED`        | `1` para desactivar la transmisión LoRa (modo solo recepción).              |
+
+**Presets de módem disponibles:**
+
+| Preset                    | Valor                                                    |
+|:--------------------------|:---------------------------------------------------------|
+| Long Fast _(por defecto)_ | `meshtastic_Config_LoRaConfig_ModemPreset_LONG_FAST`     |
+| Long Moderate             | `meshtastic_Config_LoRaConfig_ModemPreset_LONG_MODERATE` |
+| Long Turbo                | `meshtastic_Config_LoRaConfig_ModemPreset_LONG_TURBO`    |
+| Medium Fast               | `meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST`   |
+| Medium Slow               | `meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_SLOW`   |
+| Short Fast                | `meshtastic_Config_LoRaConfig_ModemPreset_SHORT_FAST`    |
+| Short Slow                | `meshtastic_Config_LoRaConfig_ModemPreset_SHORT_SLOW`    |
+| Short Turbo               | `meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO`   |
+| Lite Fast _(EU 866MHz)_   | `meshtastic_Config_LoRaConfig_ModemPreset_LITE_FAST`     |
+| Lite Slow _(EU 866MHz)_   | `meshtastic_Config_LoRaConfig_ModemPreset_LITE_SLOW`     |
+| Narrow Fast _(EU 868MHz)_ | `meshtastic_Config_LoRaConfig_ModemPreset_NARROW_FAST`   |
+| Narrow Slow _(EU 868MHz)_ | `meshtastic_Config_LoRaConfig_ModemPreset_NARROW_SLOW`   |
+
+**Códigos de región para España:**
+
+| Región        | Valor                                            |
+|:--------------|:-------------------------------------------------|
+| Europa 868MHz | `meshtastic_Config_LoRaConfig_RegionCode_EU_868` |
+| Europa 433MHz | `meshtastic_Config_LoRaConfig_RegionCode_EU_433` |
+
+</details>
+
+<details>
+<summary><strong>Canales</strong> :mdi-forum-outline:</summary>
+
+Se pueden preconfigurar hasta **3 canales** (índices 0, 1 y 2).
+
+| Parámetro                              | Descripción                                                                                                                        |
+|:---------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------|
+| `USERPREFS_CHANNELS_TO_WRITE`          | Número de canales a inicializar en el arranque (`1` a `3`).                                                                        |
+| `USERPREFS_CHANNEL_0_NAME`             | Nombre del canal (máx. 11 caracteres). Disponible también para `_1_` y `_2_`.                                                      |
+| `USERPREFS_CHANNEL_0_PSK`              | Clave precompartida. Usa `{ 0x01 }` para la clave pública por defecto, o un array de 32 bytes hexadecimales para un canal privado. |
+| `USERPREFS_CHANNEL_0_PRECISION`        | Precisión de ubicación para el canal (ej. `14` = alta, valores bajos = menor precisión).                                           |
+| `USERPREFS_CHANNEL_0_UPLINK_ENABLED`   | `true` o `false` — si el canal sube mensajes a MQTT.                                                                               |
+| `USERPREFS_CHANNEL_0_DOWNLINK_ENABLED` | `true` o `false` — si el canal descarga mensajes de MQTT.                                                                          |
+
+</details>
+
+<details>
+<summary><strong>Posición GPS fija</strong> :mdi-crosshairs-gps:</summary>
+
+Ideal para nodos estáticos (repetidores, nodos solares) que no tienen módulo GPS.
+
+| Parámetro                 | Descripción                                      |
+|:--------------------------|:-------------------------------------------------|
+| `USERPREFS_FIXED_GPS`     | `true` para activar la posición fija.            |
+| `USERPREFS_FIXED_GPS_LAT` | Latitud en formato decimal (ej. `"40.284297"`).  |
+| `USERPREFS_FIXED_GPS_LON` | Longitud en formato decimal (ej. `"-3.927447"`). |
+| `USERPREFS_FIXED_GPS_ALT` | Altitud en metros (ej. `"650"`). Opcional.       |
+
+:::warning
+
+Las coordenadas GPS fijas solo se aplican durante el **primer arranque** o justo después de un **restablecimiento de fábrica**. Si el dispositivo ya ha arrancado antes, no sobreescribirá las coordenadas almacenadas.
+
+:::
+
+</details>
+
+<details>
+<summary><strong>Administración remota</strong> :mdi-remote:</summary>
+
+Se pueden preconfigurar hasta 3 claves públicas de administración remota. Cuando otro nodo envíe un comando
+administrativo firmado con la clave privada correspondiente, este nodo lo aceptará. Tienes más contexto en la
+[guía de administración remota](./administracion-remota.md).
+
+| Parámetro                   | Descripción                                                                  |
+|:----------------------------|:-----------------------------------------------------------------------------|
+| `USERPREFS_USE_ADMIN_KEY_0` | Clave pública principal del administrador (array de 32 bytes hexadecimales). |
+| `USERPREFS_USE_ADMIN_KEY_1` | Clave pública secundaria.                                                    |
+| `USERPREFS_USE_ADMIN_KEY_2` | Clave pública terciaria.                                                     |
+
+:::tip
+
+La clave que debes poner aquí es la **clave pública** (_public key_) de tu nodo administrador personal, formateada en hexadecimal byte a byte. **Nunca** introduzcas una clave privada.
+
+:::
+
+</details>
+
+<details>
+<summary><strong>Intervalos de posición y telemetría</strong> :mdi-timer-outline:</summary>
+
+| Parámetro                                          | Descripción                                                                                      |
+|:---------------------------------------------------|:-------------------------------------------------------------------------------------------------|
+| `USERPREFS_CONFIG_POSITION_BROADCAST_INTERVAL`     | Cada cuántos segundos se emite la posición (ej. `86400` = una vez al día).                       |
+| `USERPREFS_CONFIG_GPS_UPDATE_INTERVAL`             | Cada cuántos segundos se consulta el módulo GPS.                                                 |
+| `USERPREFS_CONFIG_SMART_POSITION_ENABLED`          | `true` o `false` — emite posición solo cuando el nodo se ha movido.                              |
+| `USERPREFS_CONFIG_GPS_MODE`                        | Modo del GPS. Usa `meshtastic_Config_PositionConfig_GpsMode_DISABLED` para apagarlo.             |
+| `USERPREFS_CONFIG_DEVICE_TELEM_UPDATE_INTERVAL`    | Intervalo de telemetría del dispositivo, en segundos.                                            |
+| `USERPREFS_CONFIG_ENV_TELEM_UPDATE_INTERVAL`       | Intervalo de telemetría ambiental (sensores), en segundos.                                       |
+| `USERPREFS_CONFIG_ENVIRONMENT_MEASUREMENT_ENABLED` | `1` para forzar lecturas de sensores (BMP280, etc.) y emisión por LoRa desde el primer arranque. |
+
+</details>
+
+<details>
+<summary><strong>MQTT</strong> :mdi-cloud-outline:</summary>
+
+| Parámetro                           | Descripción                                                                                    |
+|:------------------------------------|:-----------------------------------------------------------------------------------------------|
+| `USERPREFS_MQTT_ENABLED`            | `1` para activar el módulo MQTT.                                                               |
+| `USERPREFS_MQTT_ADDRESS`            | Dirección del broker (ej. `"'mqtt.meshtastic.es'"`). Ojo con las comillas simples adicionales. |
+| `USERPREFS_MQTT_USERNAME`           | Usuario MQTT.                                                                                  |
+| `USERPREFS_MQTT_PASSWORD`           | Contraseña MQTT.                                                                               |
+| `USERPREFS_MQTT_ENCRYPTION_ENABLED` | `true` para cifrar los paquetes enviados por MQTT.                                             |
+| `USERPREFS_MQTT_TLS_ENABLED`        | `true` o `false` para habilitar TLS.                                                           |
+| `USERPREFS_MQTT_ROOT_TOPIC`         | Tema raíz personalizado (ej. `"event/mi-evento"`).                                             |
+
+</details>
+
+<details>
+<summary><strong>WiFi (solo ESP32)</strong> :mdi-wifi:</summary>
+
+| Parámetro                             | Descripción                              |
+|:--------------------------------------|:-----------------------------------------|
+| `USERPREFS_NETWORK_WIFI_ENABLED`      | `true` para activar WiFi en el arranque. |
+| `USERPREFS_NETWORK_WIFI_SSID`         | Nombre de la red WiFi.                   |
+| `USERPREFS_NETWORK_WIFI_PSK`          | Contraseña WiFi.                         |
+| `USERPREFS_NETWORK_ENABLED_PROTOCOLS` | `1` para habilitar UDP mesh por red.     |
+| `USERPREFS_NETWORK_IPV6_ENABLED`      | `1` para habilitar IPv6.                 |
+
+</details>
+
+<details>
+<summary><strong>Branding OEM (pantalla de inicio personalizada)</strong> :mdi-monitor:</summary>
+
+Puedes sustituir el logo y texto de arranque de Meshtastic por uno personalizado de tu comunidad o grupo.
+
+| Parámetro                    | Descripción                                                                 |
+|:-----------------------------|:----------------------------------------------------------------------------|
+| `USERPREFS_OEM_TEXT`         | Texto personalizado en la pantalla de arranque (ej. `"Meshtastic España"`). |
+| `USERPREFS_OEM_FONT_SIZE`    | Tamaño de fuente (`0` = pequeño, `1` = mediano, `2` = grande).              |
+| `USERPREFS_OEM_IMAGE_WIDTH`  | Ancho del logo personalizado, en píxeles.                                   |
+| `USERPREFS_OEM_IMAGE_HEIGHT` | Alto del logo personalizado, en píxeles.                                    |
+| `USERPREFS_OEM_IMAGE_DATA`   | Datos de imagen como array de bytes XBM (ej. `{ 0x00, 0xFF, ... }`).        |
+
+</details>
+
+<details>
+<summary><strong>Notificaciones y zona horaria</strong> :mdi-bell-outline:</summary>
+
+| Parámetro                     | Descripción                                                                                                            |
+|:------------------------------|:-----------------------------------------------------------------------------------------------------------------------|
+| `USERPREFS_RINGTONE_RTTTL`    | Tono de notificación personalizado en [formato RTTTL](https://en.wikipedia.org/wiki/Ring_Tone_Text_Transfer_Language). |
+| `USERPREFS_RINGTONE_NAG_SECS` | Segundos antes de repetir la notificación de mensaje no leído (ej. `60`).                                              |
+| `USERPREFS_TZ_STRING`         | Zona horaria en formato POSIX. Para España peninsular: `"CET-1CEST,M3.5.0,M10.5.0/3"`. Para Canarias: `"WET0WEST,M3.5.0/1,M10.5.0"`. |
+
+</details>
+
+<details>
+<summary><strong>Modo evento</strong> :mdi-calendar-star:</summary>
+
+Configuraciones especiales para eventos con muchos nodos.
+
+| Parámetro                    | Descripción                                                                                                                                                                                                                        |
+|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `USERPREFS_EVENT_MODE`       | `1` para activar el modo evento. Aplica restricciones estrictas: limita saltos a 2, aumenta retardos, bloquea puertos no esenciales, degrada roles Router a Client, limita posición a 1 emisión cada 5 min y bloquea MQTT público. |
+| `USERPREFS_FIRMWARE_EDITION` | Etiqueta la edición del _firmware_ para que las apps (iOS/Android) muestren temas específicos del evento.                                                                                                                            |
+
+</details>
+
+</div>


### PR DESCRIPTION
~He~ Codex ha añadido el `git submodule update --init` que no estaba puesto (muy bien detectado por GPT-5.5) y se ha movido la lista de parámetros al final, para que la _build_ y el _upload_ estén antes.