### PR TITLE
Actualizacion de la documentacion sobre el preset mas usado

### DIFF
--- a/blog/2026-03-13-multiples-tests-sfnarrow.md
+++ b/blog/2026-03-13-multiples-tests-sfnarrow.md
@@ -46,7 +46,7 @@ condiciones.
 - _Coding Rate_: `5`
 - _Frequency slot_: `4`
 - _Frequency override_: `869.618`
-- [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow+SF7+-+Slot+4)
+- [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow)
 
 #### Prueba 2 - del 28/03/2026 al 08/04/2026
 
@@ -82,7 +82,7 @@ condiciones.
 - _Coding Rate_: `5`
 - _Frequency slot_: `4`
 - _Frequency override_: `869.618`
-- [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow+SF7+-+Slot+4)
+- [Enlace al QR de configuración](/docs/generador-configuracion?preset=SFNarrow)
 
 :::info
 

--- a/blog/2026-05-25-test-sfnarrow-murcia.md
+++ b/blog/2026-05-25-test-sfnarrow-murcia.md
@@ -161,8 +161,7 @@ Es decir hacemos un uso mucho mas eficiente y respetuoso de la banda que estamos
 - **NARROW_868 en el horizonte**: Meshtastic está desarrollando una región oficial
   `NARROW_868` con 3 canales y bandas de guarda. La división actual de 4 slots **no
   será compatible** con esa futura región, por lo que la configuración definitiva aún
-  está por determinar. Por esto se mantiene MediumFast como malla principal y SFNarrow
-  como experimento paralelo.
+  está por determinar.
 - **SX1276 incompatible con SF6**: chips como el del Heltec V2 no soportan SF6. Para
   la Prueba 6 actual (SF7) no hay problema.
 

--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -110,8 +110,8 @@ Ahora viene la parte más importante de la configuración, ya que si esto está 
     | _Ancho de banda_           | **62**                                                                                                           |
     | _Factor de dispersión_     | **7**                                                                                                            |
     | _Tasa de codificación_     | **5**                                                                                                            |
-    | _Region (frequency plan)_  | **European Union 868MHz**                                                                                        |
-    | _Hop limit_                | **≤ 4**. Consulta las [buenas prácticas de saltos](../buenas-practicas.md#cantidad-de-saltos-máxima).            |
+    | _Region_                   | **European Union 868MHz** EU_868                                                                                 |
+    | _Saltos_                   | **≤ 4**. Consulta las [buenas prácticas de saltos](../buenas-practicas.md#cantidad-de-saltos-máxima).            |
     | _Override Duty Cycle_      | **NO** (es ilegal y perjudica a la malla)                                                                        |
     | _Override frequency (MHz)_ | **869.618**                                                                                                      |
 

--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -110,7 +110,7 @@ Ahora viene la parte más importante de la configuración, ya que si esto está 
     | _Ancho de banda_           | **62**                                                                                                           |
     | _Factor de dispersión_     | **7**                                                                                                            |
     | _Tasa de codificación_     | **5**                                                                                                            |
-    | _Region_                   | **European Union 868MHz** EU_868                                                                                 |
+    | _Region_                   | **European Union 868MHz** (EU_868)                                                                                 |
     | _Saltos_                   | **≤ 4**. Consulta las [buenas prácticas de saltos](../buenas-practicas.md#cantidad-de-saltos-máxima).            |
     | _Override Duty Cycle_      | **NO** (es ilegal y perjudica a la malla)                                                                        |
     | _Override frequency (MHz)_ | **869.618**                                                                                                      |
@@ -153,6 +153,13 @@ Accede [aquí al generador de QRs](../generador-configuracion).
 Comprueba qué preset se usa en tu zona en el [mapa de Presets](../mapas#mapa-presets) o en [Meshview](https://meshview.meshtastic.es).
 :::
 
+:::info
+Aunque permitas uplink y downlink en los canales, tus comunicaciones van a seguir viajando siempre a traves de RF.
+Nuestro servidor MQTT está configurado para no transportar los mensajes y no "ayudar" a la malla RF, por tanto los nodos **no utilizan internet** para comunicarse entre ellos.
+El objetivo de habilitar up y downlink en todos los canales es poder usar [herramientas](../mapas) de diagnóstico para estudiar, pulir y tener vision sobre el correcto funcionamiento de la malla.
+
+[Más info](../preguntas-frecuentes#mqtt-downlink)
+:::
 ---
 
 Una vez configurado todo esto, ya deberías poder comunicarte con otros nodos por radiofrecuencia.

--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -106,11 +106,14 @@ Ahora viene la parte más importante de la configuración, ya que si esto está 
 
     | Campo                      | Valor                                                                                                            |
     |----------------------------|------------------------------------------------------------------------------------------------------------------|
-    | _Modem Preset_             | `MEDIUM_FAST` (El más utilizado en España)<br/>`LONG_FAST` (El por defecto del firmware)                         |
+    | _Predefinido_              | Desmarca la opción                                                                                               |
+    | _Ancho de banda_           | **62**                                                                                                           |
+    | _Factor de dispersión_     | **7**                                                                                                            |
+    | _Tasa de codificación_     | **5**                                                                                                            |
     | _Region (frequency plan)_  | **European Union 868MHz**                                                                                        |
     | _Hop limit_                | **≤ 4**. Consulta las [buenas prácticas de saltos](../buenas-practicas.md#cantidad-de-saltos-máxima).            |
     | _Override Duty Cycle_      | **NO** (es ilegal y perjudica a la malla)                                                                        |
-    | _Override frequency (MHz)_ | **869.525**                                                                                                      |
+    | _Override frequency (MHz)_ | **869.618**                                                                                                      |
 
     (Hay más opciones, pero no son necesarias para la configuración inicial)
 

--- a/docs/guias-basicas/configuracion-inicial.mdx
+++ b/docs/guias-basicas/configuracion-inicial.mdx
@@ -116,204 +116,39 @@ Ahora viene la parte más importante de la configuración, ya que si esto está 
 
 ## Canales públicos 🗣️ {#canales-publicos}
 
-Por defecto el canal público se llama igual que el _preset_, es decir, **MediumFast** o **LongFast**.
-Recomendamos dejar ese canal como canal 0 (o primario) ya que es por donde se envían la telemetría, entre otras cosas.
-
-:::info
-
-En España, los canales públicos tienen todos la misma clave, que es la clave por defecto: `AQ==`
-
-:::
+Por defecto el canal público se llama igual que el _preset_, es decir, **SFNarrow** en la mayoría de zonas (consulta el [mapa](../mapas#mapa-presets)).
+Recomendamos dejar ese canal como canal 0 (o primario) ya que es por donde se envía la telemetría entre otras cosas.
 
 Los canales acordados en España son los siguientes:
 
-- **MediumFast** o **LongFast**, el canal por defecto del _preset_.
-- **Iberia**, un canal para la península ibérica acordado con nuestros [vecinos portugueses 🇵🇹](https://meshtastic.pt/).
-- Un canal de provincia, como **Madrid**, **Barcelona**, **Valencia**, **Cadiz**, **LaRioja**... sin espacios ni acentos.
+- **SFNarrow**, el canal por defecto del _preset_.
 
-    |                    | MediumFast<br/>LongFast | Iberia | Provincia |
-    |--------------------|-------------------------|--------|-----------|
-    | _Uplink enabled_   | ✅                       | ✅      | ✅         |
-    | _Downlink enabled_ | ✅                       | ✅      | ✅         |
-    | _Position enabled_ | ✅                       | ❌      | ❌         |
-    | _Precise location_ | ❌                       | ❌      | ❌         |
+Y opcionalmente:
+
+- Un canal de provincia, como **Madrid**, **Barcelona**, **Valencia**, **Cadiz**, **LaRioja**... sin espacios ni acentos.
+- **Test**, canal para enviar mensajes de prueba y no saturar el canal principal. Clave `Ag==`.
+- **Bots**, dedicado a bots y sistemas de mensajes automatizados. Clave `Ag==`.
+- **Iberia**, un canal para la península con posibilidad futura de servir de puente con otros sistemas.
+
+    |                    | SFNarrow | Provincia | Test | Bots | Iberia |
+    |--------------------|----------|-----------|------|------|--------|
+    | _Uplink enabled_   | ✅       | ✅        | ✅    | ✅   | ✅     |
+    | _Downlink enabled_ | ✅       | ✅        | ✅    | ✅   | ✅     |
+    | _Position enabled_ | ✅       | ❌        | ❌    | ❌   | ❌     |
+    | _Precise location_ | ❌       | ❌        | ❌    | ❌   | ❌     |
 
 Puedes crear más canales, tanto públicos como privados, entre los nodos que quieras. Elige una contraseña y compártela con quien sea necesario.
 
 ## Añade los canales que usamos en España ⚙️
 
-Código QR para añadir los canales principales. Escanea con la cámara dentro de Meshtastic y pulsa "Añadir":
+Puedes configurarlos manualmente como se indica arriba o mediante un QR.
+El QR se escanea con el móvil dentro de la app Meshtastic y pulsando "Añadir" (Android) o desde la cámara (iOS):
+
+Accede [aquí al generador de QRs](../generador-configuracion).
 
 :::tip
-Comprueba qué preset se usa en tu zona en el [mapa de Presets.](../mapas#mapa-presets)
+Comprueba qué preset se usa en tu zona en el [mapa de Presets](../mapas#mapa-presets) o en [Meshview](https://meshview.meshtastic.es).
 :::
-
-<Tabs groupId="preset">
-    <TabItem value="mediumfast" label="MediumFast">
-        <div className="container">
-            <div className="row">
-                <div className="col" style={{flex: 0}}>
-                    <QRCode value="https://meshtastic.org/e/#CgsSAQEoATABOgIIDwoREgEBGgZJYmVyaWEoATABOgASFAgBEAQ4A0ADSAFQG2gBwAYByAYB" size={200} className={`qr-code shadow--lw`} />
-                </div>
-                <div className="col">
-                    Los datos de los canales son:
-
-                    **Nombre**: `MediumFast`<br/>**Clave / PSK**: `AQ==`
-
-                    ---
-
-                    **Nombre**: `Iberia`<br/>**Clave / PSK**: `AQ==` (En Android lo puedes dejar vacío)
-                </div>
-            </div>
-        </div>
-        Enlace directo: https://meshtastic.org/e/#CgsSAQEoATABOgIIDwoREgEBGgZJYmVyaWEoATABOgASFAgBEAQ4A0ADSAFQG2gBwAYByAYB
-    </TabItem>
-    <TabItem value="longfast" label="LongFast">
-        <div className="container">
-            <div className="row">
-                <div className="col" style={{flex: 0}}>
-                    <QRCode value="https://meshtastic.org/e/#CgsSAQEoATABOgIIDwoREgEBGgZJYmVyaWEoATABOgASEggBOANAA0gBUBtoAcAGAcgGAQ" size={200} className={`qr-code shadow--lw`} />
-                </div>
-                <div className="col">
-                    Los datos de los canales son:
-
-                    **Nombre**: `LongFast`<br/>**Clave / PSK**: `AQ==`
-
-                    ---
-
-                    **Nombre**: `Iberia`<br/>**Clave / PSK**: `AQ==` (En Android lo puedes dejar vacío)
-                </div>
-            </div>
-        </div>
-        Enlace directo: https://meshtastic.org/e/#CgsSAQEoATABOgIIDwoREgEBGgZJYmVyaWEoATABOgASEggBOANAA0gBUBtoAcAGAcgGAQ
-    </TabItem>
-</Tabs>
-
-:::danger
-Al aplicar esta configuración, aceptas utilizar una precisión de ubicación aproximada de 700 metros. Cada usuario es responsable de ajustar este valor según sus necesidades.
-:::
-
-### Canales por provincias 🗺️{#canales-por-provincias}
-
-<!--
-Para añadir un nuevo canal, o modificar uno existente, puedes usar lo siguiente:
-- Entra en la web de https://www.protobufpal.com/.
-- Carga los ficheros `*.proto` de meshtastic. https://github.com/meshtastic/protobufs/tree/master/meshtastic
-- Copia el siguiente JSON en la parte derecha de la web:
-    ```
-    {
-      "settings": [
-        {
-          "psk": [1],
-          "name": "Tenerife",
-          "uplink_enabled": true,
-          "downlink_enabled": true
-        }
-      ],
-      "lora_config": {
-        "use_preset": true,
-        "hop_limit": 3,
-        "tx_enabled": true,
-        "ignore_mqtt": false,
-        "config_ok_to_mqtt": true
-      }
-    }
-    ```
-- Cambia el nombre del canal y otras configuraciones que quieras modificar.
-- Selecciona el Proto Message `apponly.proto - ChannelSet` y dale al botón "Encode".
-- Copia el resultado en base64 que aparece en la parte inferior.
-- Actualiza la lista de `regionConfigs` con el nuevo canal, su nombre, y el resultado en base64.
--->
-
-export const regionConfigs = [
-    {"name": "Álava", "channel": "Alava", "base64": "Cg4SAQEaBUFsYXZhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Albacete", "channel": "Albacete", "base64": "ChESAQEaCEFsYmFjZXRlKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Alicante", "channel": "Alicante", "base64": "ChESAQEaCEFsaWNhbnRlKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Almería", "channel": "Almeria", "base64": "ChASAQEaB0FsbWVyaWEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Ávila", "channel": "Avila", "base64": "Cg4SAQEaBUF2aWxhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Badajoz", "channel": "Badajoz", "base64": "ChASAQEaB0JhZGFqb3ooATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Baleares", "channel": "Baleares", "base64": "ChESAQEaCEJhbGVhcmVzKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Barcelona", "channel": "Barcelona", "base64": "ChISAQEaCUJhcmNlbG9uYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Burgos", "channel": "Burgos", "base64": "Cg8SAQEaBkJ1cmdvcygBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Cáceres", "channel": "Caceres", "base64": "ChASAQEaB0NhY2VyZXMoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Cádiz", "channel": "Cadiz", "base64": "Cg4SAQEaBUNhZGl6KAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Castellón", "channel": "Castellon", "base64": "ChISAQEaCUNhc3RlbGxvbigBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Ciudad Real", "channel": "CiudadReal", "base64": "ChMSAQEaCkNpdWRhZFJlYWwoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Córdoba", "channel": "Cordoba", "base64": "ChASAQEaB0NvcmRvYmEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "A Coruña", "channel": "ACoruña", "base64": "ChESAQEaCEFDb3J1w7FhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Cuenca", "channel": "Cuenca", "base64": "Cg8SAQEaBkN1ZW5jYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Girona", "channel": "Girona", "base64": "Cg8SAQEaBkdpcm9uYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Granada", "channel": "Granada", "base64": "ChASAQEaB0dyYW5hZGEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Guadalajara", "channel": "Guadalajara", "base64": "ChQSAQEaC0d1YWRhbGFqYXJhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Gipuzkoa", "channel": "Gipuzkoa", "base64": "ChESAQEaCEdpcHV6a29hKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Huelva", "channel": "Huelva", "base64": "Cg8SAQEaBkh1ZWx2YSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Huesca", "channel": "Huesca", "base64": "Cg8SAQEaBkh1ZXNjYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Jaén", "channel": "Jaen", "base64": "Cg0SAQEaBEphZW4oATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Islas Canarias", "channel": "Canarias", "base64": "ChESAQEaCENhbmFyaWFzKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "León", "channel": "Leon", "base64": "Cg0SAQEaBExlb24oATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Lleida", "channel": "Lleida", "base64": "Cg8SAQEaBkxsZWlkYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "La Rioja", "channel": "LaRioja", "base64": "ChASAQEaB0xhUmlvamEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Lugo", "channel": "Lugo", "base64": "Cg0SAQEaBEx1Z28oATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Madrid", "channel": "Madrid", "base64": "Cg8SAQEaBk1hZHJpZCgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Málaga", "channel": "Malaga", "base64": "Cg8SAQEaBk1hbGFnYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Murcia", "channel": "Murcia", "base64": "Cg8SAQEaBk11cmNpYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Navarra", "channel": "Navarra", "base64": "ChASAQEaB05hdmFycmEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Ourense", "channel": "Ourense", "base64": "ChASAQEaB091cmVuc2UoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Asturias", "channel": "Asturias", "base64": "ChESAQEaCEFzdHVyaWFzKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Palencia", "channel": "Palencia", "base64": "ChESAQEaCFBhbGVuY2lhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Pontevedra", "channel": "Pontevedra", "base64": "ChMSAQEaClBvbnRldmVkcmEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Salamanca", "channel": "Salamanca", "base64": "ChISAQEaCVNhbGFtYW5jYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Cantabria", "channel": "Cantabria", "base64": "ChISAQEaCUNhbnRhYnJpYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Segovia", "channel": "Segovia", "base64": "ChASAQEaB1NlZ292aWEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Sevilla", "channel": "Sevilla", "base64": "ChASAQEaB1NldmlsbGEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Soria", "channel": "Soria", "base64": "Cg4SAQEaBVNvcmlhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Tarragona", "channel": "Tarragona", "base64": "ChISAQEaCVRhcnJhZ29uYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Teruel", "channel": "Teruel", "base64": "Cg8SAQEaBlRlcnVlbCgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Toledo", "channel": "Toledo", "base64": "Cg8SAQEaBlRvbGVkbygBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Valencia", "channel": "Valencia", "base64": "ChESAQEaCFZhbGVuY2lhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Valladolid", "channel": "Valladolid", "base64": "ChMSAQEaClZhbGxhZG9saWQoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Bizkaia", "channel": "Bizkaia", "base64": "ChASAQEaB0JpemthaWEoATABEgwIAUADSAHABgDIBgE"},
-    {"name": "Zamora", "channel": "Zamora", "base64": "Cg8SAQEaBlphbW9yYSgBMAESDAgBQANIAcAGAMgGAQ"},
-    {"name": "Zaragoza", "channel": "Zaragoza", "base64": "ChESAQEaCFphcmFnb3phKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Ceuta", "channel": "Ceuta", "base64": "Cg4SAQEaBUNldXRhKAEwARIMCAFAA0gBwAYAyAYB"},
-    {"name": "Melilla", "channel": "Melilla", "base64": "ChASAQEaB01lbGlsbGEoATABEgwIAUADSAHABgDIBgE"}
-]
-
-export const QRsProvinciales = () => {
-    const [selectedRegion, setSelectedRegion] = useState(regionConfigs[0].channel);
-    const region = regionConfigs.find((region) => region.channel === selectedRegion);
-    const regionLink = "https://meshtastic.org/e/?add=true#" + region.base64;
-    return <>
-        <p>Código QR para añadir el canal. Escanea con la cámara dentro de Meshtastic y pulsa "Añadir".</p>
-
-        <p>
-            Selecciona una provincia o región: &nbsp;
-            <select id="selectedRegion" value={selectedRegion}
-                    onChange={(event) => setSelectedRegion(event.target.value)}>
-                {regionConfigs.map((region) => (<option value={region.channel}>{region.name}</option>))}
-            </select>
-        </p>
-
-        <div className="container">
-            <div className="row">
-                <div className="col" style={{flex: 0}}>
-                    <QRCode value={regionLink} size={200} className={`qr-code shadow--lw`}/>
-                </div>
-                <div className="col">
-                    <p>Los datos del canal son:</p>
-
-                    <p><strong>Nombre</strong>: <code>{region.channel}</code> (sin espacios ni caracteres especiales)
-                    </p>
-
-                    <p><strong>Clave / PSK</strong>: <code>AQ==</code> (En Android lo puedes dejar vacío)</p>
-                </div>
-            </div>
-        </div>
-        Enlace directo: <Link to={regionLink}>{regionLink}</Link>
-    </>
-}
-
-<QRsProvinciales />
 
 ---
 

--- a/docs/guias-diy/guia-tubo-solar-karman.md
+++ b/docs/guias-diy/guia-tubo-solar-karman.md
@@ -348,20 +348,6 @@ Ahora ya podemos conectar por bluetooth y pasar a la **[Configuración inicial](
 6. Conectar batería  
 7. Sellar ambos extremos
 
----
-
-## Configuración inicial
-
-1. Descargar APP Meshtastic  
-2. Conectar por Bluetooth (clave: `123456`)  
-3. Configurar:
-   - Región: `EU_868`
-   - Radio preset: `MediumFast`
-   - TX habilitado  
-4. Guardar y reiniciar  
-5. Configurar nombre del nodo  
-
-Más info: [https://meshtastic.es](https://meshtastic.es)
 
 ---
 

--- a/docs/mapas.md
+++ b/docs/mapas.md
@@ -69,7 +69,7 @@ import MapaEspana from '@site/src/components/MapaRegiones/MapaEspana';
 Estos son los pasos a seguir:
 
 1. **Configura la posición**. En caso de nodos estáticos, puedes configurar una posición fija. No te olvides de echarle un vistazo a las [buenas prácticas de intervalos de posición](buenas-practicas.md#posición).
-2. **Comparte la ubicación**. En la configuración del canal principal (MediumFast, LongFast...) activa la posición y configura la precisión al gusto.
+2. **Comparte la ubicación**. En la configuración del canal principal activa la posición y configura la precisión al gusto.
 3. **Permite enviar datos a MQTT**. En la configuración de LoRa, activa _Ok to MQTT_ para poder enviar datos al servidor.
 4. Dependiendo de qué nodo tengas:
     - En caso de nodos con Internet y conectados al servidor MQTT, **habilita _map reporting_** en la configuración de MQTT, al final del todo.

--- a/docs/preguntas-frecuentes.md
+++ b/docs/preguntas-frecuentes.md
@@ -13,19 +13,14 @@ export const KeyOffIcon = () => (
 </svg>
 );
 
-## Enviar mensajes por MQTT en el canal principal o Iberia {#mqtt-downlink}
+## Enviar mensajes por MQTT {#mqtt-downlink}
 
-En el servidor MQTT hemos deshabilitado el _downlink_ a los canales con nombre de _presets_ 
-e Iberia. Esto se hizo para evitar que los nodos se saturen con paquetes de toda España y probablemente consuman el
-[_duty cycle_](#duty-cycle).
+En el servidor MQTT hemos deshabilitado el _downlink_ a todos los canales. No se puede habilitar porque los nodos se saturarían con todos los paquetes de toda España al mismo tiempo consumuendo todo el _Airtime_.
+Además, queremos promover una malla fuerte en RF y para ello no creemos que deba apoyarse en Internet.
 
-Sin embargo, <u>es **importante** mantener activado</u> en los nodos tanto _uplink_ como _downlink_ en estos canales, ya
-que nos da más agilidad en el futuro si cambiamos algo en el servidor MQTT. Además, se permite que lleguen mensajes
-directos, telemetrías y otros paquetes cifrados, como por ejemplo la [administración de nodos en remoto](configuracion-avanzada/administracion-remota.md).
+Sin embargo, <u>es **importante** mantener activado</u> en los nodos tanto _uplink_ como _downlink_ en estos canales. Esto nos da más agilidad en el futuro si cambiase algo en el servidor MQTT. Además, puede permitir que se envíen mensajes directos y otros paquetes cifrados, como por ejemplo la [administración de nodos en remoto](configuracion-avanzada/administracion-remota.md) que nos podéis solicitar si fuese necesario activarlo puntualmente.
 
-La gran mayoría de los nodos en España tienen como canal principal el canal del _preset_. Al ser
-canal principal, es por donde se envían todos los paquetes de NodeInfo, telemetría variada, ubicación... todos esos datos
-que se mandan a intervalos. Si tu nodo reenviara por radiofrecuencia todo eso, llegaría rápidamente a su [_duty cycle_](#duty-cycle).
+En caso excepcional y de necesidad, mientras la mayoría de nodos tengan up y downlink activo, tendremos la opción de habilitar un refuerzo temporal de la malla usando Internet. Si hay una emergencia e Internet puede ayudar, no vamos a desaprovechar la opción de reforzar la malla.
 
 ## Problemas comunes {#problemas-comunes}
 

--- a/docs/preguntas-frecuentes.md
+++ b/docs/preguntas-frecuentes.md
@@ -15,7 +15,7 @@ export const KeyOffIcon = () => (
 
 ## Enviar mensajes por MQTT en el canal principal o Iberia {#mqtt-downlink}
 
-En el servidor MQTT hemos deshabilitado el _downlink_ a los canales con nombre de _presets_ (LongFast, MediumFast...)
+En el servidor MQTT hemos deshabilitado el _downlink_ a los canales con nombre de _presets_ 
 e Iberia. Esto se hizo para evitar que los nodos se saturen con paquetes de toda España y probablemente consuman el
 [_duty cycle_](#duty-cycle).
 
@@ -23,7 +23,7 @@ Sin embargo, <u>es **importante** mantener activado</u> en los nodos tanto _upli
 que nos da más agilidad en el futuro si cambiamos algo en el servidor MQTT. Además, se permite que lleguen mensajes
 directos, telemetrías y otros paquetes cifrados, como por ejemplo la [administración de nodos en remoto](configuracion-avanzada/administracion-remota.md).
 
-La gran mayoría de los nodos en España tienen como canal principal el canal del _preset_ (LongFast, MediumFast...). Al ser
+La gran mayoría de los nodos en España tienen como canal principal el canal del _preset_. Al ser
 canal principal, es por donde se envían todos los paquetes de NodeInfo, telemetría variada, ubicación... todos esos datos
 que se mandan a intervalos. Si tu nodo reenviara por radiofrecuencia todo eso, llegaría rápidamente a su [_duty cycle_](#duty-cycle).
 
@@ -64,8 +64,7 @@ cambia. Haz una copia de tus claves, por si tuvieras que volver a utilizarlas.
 
 ### ¿Por qué aparece un candado amarillo en un canal? <span style={{color:"yellow"}} class="shadow">:mdi-unlocked-variant-outline:</span> {#candado-amarillo-canal}
 
-El candado amarillo indica que el canal está utilizando la clave por defecto. Es normal en los canales públicos (MediumFast,
-LongFast, Iberia, canales de provincia...). No se considera tan segura porque es pública y conocida por todo el mundo.
+El candado amarillo indica que el canal está utilizando la clave por defecto. Es normal en los canales públicos. No se considera tan segura porque es pública y conocida por todo el mundo.
 
 En canales privados, cambia la clave del canal por una propia para cifrar tus comunicaciones.
 

--- a/docs/primeros-pasos.md
+++ b/docs/primeros-pasos.md
@@ -92,7 +92,7 @@ Una vez que el firmware está instalado, configura tu dispositivo para unirlo a 
    - **Región**: Selecciona tu región (por ejemplo, «Europa» para 868 MHz o «EE.UU.» para 915 MHz). Esto es obligatorio para cumplir con las regulaciones de frecuencia.
    - **Nombre del nodo**: Asigna un nombre único a tu dispositivo para identificarlo en la red (por ejemplo, «Nodo de Juan»).
    - **Canal**: Por defecto, los dispositivos usan un canal público. Puedes crear canales privados con cifrado para comunicarte solo con tu grupo. Comparte la clave de cifrado mediante un código QR o texto. El QR que usamos en España lo puedes encontrar en Telegram: [@meshtastic_esp](https://t.me/meshtastic_esp).
-   - **Preset de LoRa**: Aunque el ajuste que viene predeterminado es «Long_Fast», «Medium_Fast» es preferido por más personas debido a que tiene mejor rendimiento. Revisa qué configuración se utiliza en tu zona ya que solo podrás comunicarte con nodos que usen el mismo preset.
+   - **Preset de LoRa**: Aunque el ajuste que viene predeterminado es «Long_Fast», la mayoría de personas prefieren un ajuste personalizado (desmarcando _Usar predefinido_) debido a que tiene mejor rendimiento. Este ajuste no está en el desplegable de presets porque es de la comunidad y hay que configurarlo, se llama SFNarrow. Revisa qué configuración se utiliza en tu zona ya que solo podrás comunicarte con nodos que usen el mismo preset.
 
 3. **Prueba la conexión**:
    - Enciende al menos dos dispositivos y verifica que se detecten mutuamente en la red. Envía un mensaje de prueba desde la app o el cliente web, como «¡Hola, estoy probando!».

--- a/src/components/MapaRegiones/MapaEspana.jsx
+++ b/src/components/MapaRegiones/MapaEspana.jsx
@@ -24,7 +24,7 @@ const presetColors = {
 };
 
 const DEFAULT_COLOR = "#ccccccff"; 
-const DEFAULT_PRESET = "MediumFast";
+const DEFAULT_PRESET = "SFNarrow";
 const NO_DATA_PRESET = "Sin Datos";
 
 

--- a/src/components/MeshtasticConfigGenerator/config.ts
+++ b/src/components/MeshtasticConfigGenerator/config.ts
@@ -8,6 +8,18 @@ export const DEFAULT_PSK = new Uint8Array([1]); // AQ== in base64 = byte value 1
 
 // Preset definitions
 export const PRESETS: Presets = {
+  'SFNarrow': {
+    label: 'BW 62, SF 7, 869.618 MHz',
+    overrideChannelName: 'SFNarrow',
+    loraConfig: {
+      usePreset: false,
+      bandwidth: 62,
+      spreadFactor: 7,
+      codingRate: 5,
+      region: DEFAULT_REGION,
+      overrideFrequency: 869.618,
+    },
+  },
   'LongFast': {
     loraConfig: {
       usePreset: true,
@@ -36,18 +48,6 @@ export const PRESETS: Presets = {
       modemPreset: ModemPreset.SHORT_FAST,
       region: DEFAULT_REGION,
       overrideFrequency: 869.525, //Al venir de las pruebas lo incluyo por si alguien lo tiene mal
-    },
-  },
-  'SFNarrow SF7 - Slot 4': {
-    label: 'BW 62, SF 7, CR 5, 869.618 MHz',
-    overrideChannelName: 'SFNarrow',
-    loraConfig: {
-      usePreset: false,
-      bandwidth: 62,
-      spreadFactor: 7,
-      codingRate: 5,
-      region: DEFAULT_REGION,
-      overrideFrequency: 869.618,
     },
   },
   'SFNarrow - Prueba SF6': {

--- a/src/components/MeshtasticConfigGenerator/index.tsx
+++ b/src/components/MeshtasticConfigGenerator/index.tsx
@@ -342,10 +342,10 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
             <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: '8px' }}>
               <input
                 type="checkbox"
-                checked={includeIberia}
-                onChange={(e) => setIncludeIberia(e.target.checked)}
+                checked={includeRegional}
+                onChange={(e) => setIncludeRegional(e.target.checked)}
               />
-              <span>Iberia</span>
+              <span>Canal provincial</span>
             </label>
 
             <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: '8px' }}>
@@ -365,14 +365,14 @@ export default function MeshtasticConfigGenerator(): React.ReactElement {
               />
               <span>Bots</span>
             </label>
-            
+
             <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: '8px' }}>
               <input
                 type="checkbox"
-                checked={includeRegional}
-                onChange={(e) => setIncludeRegional(e.target.checked)}
+                checked={includeIberia}
+                onChange={(e) => setIncludeIberia(e.target.checked)}
               />
-              <span>Canal regional</span>
+              <span>Iberia</span>
             </label>
             
             {includeRegional && (


### PR DESCRIPTION
- Reordenados presets configurador y simplificado nombre SFNarrow
- Quitadas referencias "hardcodeadas" a presets antiguos
- Cambiado "default" a preset mas usado, SFNarrow